### PR TITLE
Update iOS fakelnd command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To build the iOS version, macOS is required. You also need an Apple Developer ac
 
 To start the application:
 - Run: `yarn start-metro`
-- Run: `yarn ios:fakelnd-debug`
+- Run: `yarn ios:mainnet-fakelnd-debug`
 
 ## Commit and Code-Style
 


### PR DESCRIPTION
The `ios:fakelnd-debug` script doesn't exist in `package.json` so I assume it was meant to be `ios:mainnet-fakelnd-debug` 🙂