### PR TITLE
Add missing parenthesis

### DIFF
--- a/mocks/react-native-sqlite-storage.ts
+++ b/mocks/react-native-sqlite-storage.ts
@@ -14,9 +14,9 @@ export default {
 const mockSQLite = {
   openDatabase: (...args) => {
     return {
-      transaction: (...args) => {
+      transaction: (...args) => ({
         executeSql: (query) => { return []; }
-      }
+      })
     };
   }
 }


### PR DESCRIPTION
Without the parenthesis, `executeSql` is parsed as a code line label, not a property name