### PR TITLE
Use FileUtils.copy

### DIFF
--- a/android/app/src/main/java/com/blixtwallet/LndMobileTools.java
+++ b/android/app/src/main/java/com/blixtwallet/LndMobileTools.java
@@ -316,16 +316,7 @@ class LndMobileTools extends ReactContextBaseJavaModule {
         }
       }
 
-      InputStream in = new FileInputStream(sourceLocation);
-      OutputStream out = new FileOutputStream(targetLocation);
-
-      byte[] buf = new byte[1024];
-      int len;
-      while ((len = in.read(buf)) > 0) {
-        out.write(buf, 0, len);
-      }
-      in.close();
-      out.close();
+      FileUtils.copy(new FileInputStream(source), new FileOutputStream(destination));
 
       return targetLocation.toString();
     } catch (Throwable e) {


### PR DESCRIPTION
Untested!
This assumes we have `compileSdkVersion 29` or higher. This copy method might be faster, or if noting else, less own code to maintain.

I found this since the code scanner warned of potential memory leak (unclosed file descriptors) if copying fails. If using FileUtils won't work, we should add a `finally` block that ensures the Streams get closed and garbage collected.