### PR TITLE
add zero conf channels support (interceptor missing)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -903,6 +903,9 @@
       "disableGraphCache": {
         "title": "Disable lnd graph cache"
       },
+      "enableZeroConfChannels": {
+        "title": "Enable Zero conf channels"
+      },
       "resetMissionControl": {
         "title": "Reset payment routing knowledge"
       }

--- a/src/lndmobile/index.ts
+++ b/src/lndmobile/index.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from "react-native";
+import { EmitterSubscription, NativeModules } from "react-native";
 import { sendCommand, sendStreamCommand, decodeStreamResult } from "./utils";
 import { lnrpc, routerrpc, invoicesrpc } from "../../proto/lightning";
 import Long from "long";

--- a/src/state/Settings.ts
+++ b/src/state/Settings.ts
@@ -53,6 +53,7 @@ export interface ISettingsModel {
   changeLndNoGraphCache: Thunk<ISettingsModel, boolean>;
   changeInvoiceExpiry: Thunk<ISettingsModel, number>;
   changeRescanWallet: Thunk<ISettingsModel, boolean>;
+  changeLndZeroConfChannels: Thunk<ISettingsModel, boolean>;
   changeReceiveViaP2TR: Thunk<ISettingsModel, boolean, any, IStoreModel>;
 
   setBitcoinUnit: Action<ISettingsModel, keyof IBitcoinUnits>;
@@ -83,6 +84,7 @@ export interface ISettingsModel {
   setRequireGraphSync: Action<ISettingsModel, boolean>;
   setDunderEnabled: Action<ISettingsModel, boolean>;
   setLndNoGraphCache: Action<ISettingsModel, boolean>;
+  setLndZeroConfChannels: Action<ISettingsModel, boolean>;
   setInvoiceExpiry: Action<ISettingsModel, number>;
   setRescanWallet: Action<ISettingsModel, boolean>;
   setReceiveViaP2TR: Action<ISettingsModel, boolean>;
@@ -115,6 +117,7 @@ export interface ISettingsModel {
   requireGraphSync: boolean;
   dunderEnabled: boolean;
   lndNoGraphCache: boolean;
+  lndZeroConfChannels: boolean;
   invoiceExpiry: number;
   rescanWallet: boolean;
   receiveViaP2TR: boolean;
@@ -151,6 +154,7 @@ export const settings: ISettingsModel = {
     actions.setRequireGraphSync(await getItemObject(StorageItem.requireGraphSync) ?? false);
     actions.setDunderEnabled(await getItemObject(StorageItem.dunderEnabled) ?? false);
     actions.setLndNoGraphCache(await getItemObject(StorageItem.lndNoGraphCache) ?? false);
+    actions.setLndZeroConfChannels(await getItemObject(StorageItem.lndZeroConfChannels) ?? false);
     actions.setInvoiceExpiry(await getItemObject(StorageItem.invoiceExpiry) ?? DEFAULT_INVOICE_EXPIRY);
     actions.setRescanWallet(await getRescanWallet());
     actions.setReceiveViaP2TR(await getItemObject(StorageItem.receiveViaP2TR) ?? false);
@@ -301,6 +305,11 @@ export const settings: ISettingsModel = {
     actions.setLndNoGraphCache(payload);
   }),
 
+  changeLndZeroConfChannels: thunk(async (actions, payload) => {
+    await setItemObject(StorageItem.lndZeroConfChannels, payload);
+    actions.setLndZeroConfChannels(payload);
+  }),
+
   changeInvoiceExpiry: thunk(async (actions, payload) => {
     await setItemObject(StorageItem.invoiceExpiry, payload);
     actions.setInvoiceExpiry(payload);
@@ -345,6 +354,7 @@ export const settings: ISettingsModel = {
   setRequireGraphSync: action((state, payload) => { state.requireGraphSync = payload; }),
   setDunderEnabled: action((state, payload) => { state.dunderEnabled = payload; }),
   setLndNoGraphCache: action((state, payload) => { state.lndNoGraphCache = payload; }),
+  setLndZeroConfChannels: action((state, payload) => { state.lndZeroConfChannels = payload; }),
   setInvoiceExpiry: action((state, payload) => { state.invoiceExpiry = payload; }),
   setRescanWallet: action((state, payload) => { state.rescanWallet = payload; }),
   setReceiveViaP2TR: action((state, payload) => { state.receiveViaP2TR = payload; }),
@@ -377,6 +387,7 @@ export const settings: ISettingsModel = {
   requireGraphSync: false,
   dunderEnabled: false,
   lndNoGraphCache: false,
+  lndZeroConfChannels: false,
   invoiceExpiry: DEFAULT_INVOICE_EXPIRY,
   rescanWallet: false,
   receiveViaP2TR: false,

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -414,6 +414,7 @@ export const model: IStoreModel = {
     const bitcoindPubRawBlock = await getItemAsyncStorage(StorageItem.bitcoindPubRawBlock) || null;
     const bitcoindPubRawTx = await getItemAsyncStorage(StorageItem.bitcoindPubRawTx) || null;
     const lndNoGraphCache = await getItemAsyncStorage(StorageItem.lndNoGraphCache) || "0";
+    const lndZeroConfChannels = await getItemAsyncStorage(StorageItem.lndZeroConfChannels) || "0";
 
     const nodeBackend = lndChainBackend === "neutrino" ? "neutrino" : "bitcoind";
 
@@ -469,6 +470,7 @@ autopilot.heuristic=preferential:${Chain === "testnet" || Chain === "mainnet" ? 
 [protocol]
 protocol.wumbo-channels=true
 protocol.option-scid-alias=true
+protocol.zero-conf=${lndZeroConfChannels.toString()}
 `;
     await writeConfig(config);
   }),

--- a/src/storage/app.ts
+++ b/src/storage/app.ts
@@ -58,6 +58,7 @@ export enum StorageItem { // const enums not supported in Babel 7...
   requireGraphSync = "requireGraphSync",
   dunderEnabled = "dunderEnabled",
   lndNoGraphCache = "lndNoGraphCache",
+  lndZeroConfChannels ="lndZeroConfChannels",
   invoiceExpiry = "invoiceExpiry", // in seconds
   rescanWallet = "rescanWallet",
   receiveViaP2TR = "receiveViaP2TR",
@@ -139,6 +140,7 @@ export const clearApp = async () => {
     removeItem(StorageItem.requireGraphSync),
     removeItem(StorageItem.dunderEnabled),
     removeItem(StorageItem.lndNoGraphCache),
+    removeItem(StorageItem.lndZeroConfChannels),
     removeItem(StorageItem.invoiceExpiry),
     removeItem(StorageItem.rescanWallet),
     removeItem(StorageItem.receiveViaP2TR),
@@ -216,6 +218,7 @@ export const setupApp = async () => {
     setItemObject<boolean>(StorageItem.requireGraphSync, false),
     setItemObject<boolean>(StorageItem.dunderEnabled, false),
     setItemObject<boolean>(StorageItem.lndNoGraphCache, false),
+    setItemObject<boolean>(StorageItem.lndZeroConfChannels, false),
     setItemObject<number>(StorageItem.invoiceExpiry, DEFAULT_INVOICE_EXPIRY),
     setItemObject<boolean>(StorageItem.rescanWallet, false),
     setItemObject<boolean>(StorageItem.receiveViaP2TR, false),

--- a/src/windows/Settings/Settings.tsx
+++ b/src/windows/Settings/Settings.tsx
@@ -26,6 +26,7 @@ import { getNodeInfo, resetMissionControl } from "../../lndmobile";
 
 import { useTranslation } from "react-i18next";
 import { languages, namespaces } from "../../i18n/i18n.constants";
+import {channelAcceptor} from '../../lndmobile/index';
 
 let ReactNativePermissions: any;
 if (PLATFORM !== "macos") {
@@ -974,6 +975,13 @@ ${t("experimental.tor.disabled.msg2")}`;
     await changeLndNoGraphCache(!lndNoGraphCache);
   };
 
+  // Lnd Zero Conf Channels
+  const lndZeroConfChannels = useStoreState((store) => store.settings.lndZeroConfChannels);
+  const changeLndZeroConfChannels = useStoreActions((store) => store.settings.changeLndZeroConfChannels);
+  const onToggleLndZeroConfChannels = async () => {
+    await changeLndZeroConfChannels(!lndZeroConfChannels);
+  }
+
   // Invoice expiry
   const invoiceExpiry = useStoreState((store) => store.settings.invoiceExpiry);
   const changeInvoiceExpiry = useStoreActions((store) => store.settings.changeInvoiceExpiry);
@@ -1489,6 +1497,15 @@ ${t("experimental.tor.disabled.msg2")}`;
             </Body>
             <Right><CheckBox checked={lndNoGraphCache} onPress={onToggleLndNoGraphCache} /></Right>
           </ListItem>
+
+          <ListItem style={style.listItem} button={true} icon={true} onPress={onToggleLndZeroConfChannels}>
+            <Left><Icon style={style.icon} type="MaterialCommunityIcons" name="database-sync" /></Left>
+            <Body>
+              <Text>{t("debug.enableZeroConfChannels.title")}</Text>
+            </Body>
+            <Right><CheckBox checked={lndZeroConfChannels} onPress={onToggleLndZeroConfChannels} /></Right>
+          </ListItem>
+
           <ListItem style={style.listItem} icon={true} onPress={() => {
             writeConfig();
             toast(t("msg.written",{ns:namespaces.common}))


### PR DESCRIPTION
Added support for zero conf channels in the UI and the toggle adds it to the conf file but it won't work without an active interceptor to accept/reject the inbound channel request.

Didn't know what icon to use for the settings option, just put in "database-sync" for now.