### PR TITLE
Fix spacing issue for restore seed words

### DIFF
--- a/src/windows/Welcome/Restore.tsx
+++ b/src/windows/Welcome/Restore.tsx
@@ -48,7 +48,8 @@ export default function Restore({ navigation }: IProps) {
   const onRestorePress = async () => {
     try {
       // Note: the first trim is not a mistake, it's to trim out "white-space words" that could exist after the split
-      const splittedSeed = seedText.trim().split(" ").map((word) => word.trim());
+      const splittedSeed = seedText.trim().split(" ").filter(word => word !== '').map((word) => word.trim());
+
       if (splittedSeed.length !== 24) {
         Alert.alert(t("restore.seed"));
         return;


### PR DESCRIPTION
You can enter any number of spaces between words when entering seed phrase now.

https://github.com/hsjoberg/blixt-wallet/issues/998