### PR TITLE
Added ability to force close pendingchannel

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -274,6 +274,7 @@
       "localCommitmentTxid": "Local commitment TXID",
       "remoteCommitmentTxid": "Remote commitment TXID",
       "closeChannel": "Close channel",
+      "forceClosePendingChannel": "Force Close Pending Channel",
       "closeChannelPrompt": {
         "title": "Close channel"
       }

--- a/src/components/PendingChannelCard.tsx
+++ b/src/components/PendingChannelCard.tsx
@@ -41,7 +41,7 @@ export const PendingChannelCard = ({ channel, type, alias }: IPendingChannelCard
   }
 
   const close = (channel: lnrpc.PendingChannelsResponse.IWaitingCloseChannel) => {
-    if (!!channel.closingTxid) {
+    if (!!channel.closingTxid || channel.closingTxid !== '') {
       Alert.alert("Closing Tx Has Already Been Broadcasted");
       return;
     }
@@ -68,7 +68,7 @@ export const PendingChannelCard = ({ channel, type, alias }: IPendingChannelCard
               outputIndex: Number.parseInt(channelPoint.split(":")[1], 10),
               force: true,
             });
-            
+
             Alert.alert("Force Closed Channel");
           } catch(err) {
             console.log(err);


### PR DESCRIPTION
Added the ability to force close a pending channel.
Only force closes if the existing channel has no pending tx_id.

https://github.com/hsjoberg/blixt-wallet/issues/1052