### PR TITLE
Calculate fee limit using * instead of mul, passthrough payment amount

### DIFF
--- a/src/lndmobile/index.ts
+++ b/src/lndmobile/index.ts
@@ -202,7 +202,7 @@ export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, pay_amo
     noInflightUpdates: true,
     timeoutSeconds: 60,
     maxParts: multiPath ? 16 : 1,
-    feeLimitSat: Long.fromValue(Math.max(10, pay_amount * 0.02)).toInt(),
+    feeLimitSat: Long.fromValue(Math.max(10, pay_amount * 0.02)),
     cltvLimit: 0,
   };
   if (amount) {

--- a/src/lndmobile/index.ts
+++ b/src/lndmobile/index.ts
@@ -196,13 +196,13 @@ export const sendPaymentSync = async (paymentRequest: string, amount?: Long, tlv
 };
 
 
-export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, tlvRecordName?: string | null, multiPath?: boolean): Promise<lnrpc.Payment> => {
+export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, pay_amount: Long, tlvRecordName?: string | null, multiPath?: boolean): Promise<lnrpc.Payment> => {
   const options: routerrpc.ISendPaymentRequest = {
     paymentRequest,
     noInflightUpdates: true,
     timeoutSeconds: 60,
-    maxParts: multiPath ? 2 : undefined,
-    feeLimitSat: Long.fromValue(Math.max(10, amount?.mul(0.02).toNumber() ?? 0)),
+    maxParts: multiPath ? 16 : 1,
+    feeLimitSat: Long.fromValue(Math.max(10, pay_amount * 0.02)).toInt(),
     cltvLimit: 0,
   };
   if (amount) {

--- a/src/lndmobile/index.ts
+++ b/src/lndmobile/index.ts
@@ -196,13 +196,13 @@ export const sendPaymentSync = async (paymentRequest: string, amount?: Long, tlv
 };
 
 
-export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, pay_amount: Long, tlvRecordName?: string | null, multiPath?: boolean): Promise<lnrpc.Payment> => {
+export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, payAmount: Long, tlvRecordName?: string | null, multiPath?: boolean): Promise<lnrpc.Payment> => {
   const options: routerrpc.ISendPaymentRequest = {
     paymentRequest,
     noInflightUpdates: true,
     timeoutSeconds: 60,
     maxParts: multiPath ? 16 : 1,
-    feeLimitSat: Long.fromValue(Math.max(10, pay_amount * 0.02)),
+    feeLimitSat: Long.fromValue(Math.max(10, payAmount * 0.02)),
     cltvLimit: 0,
   };
   if (amount) {

--- a/src/state/Send.ts
+++ b/src/state/Send.ts
@@ -140,6 +140,7 @@ export const send: ISendModel = {
     const sendPaymentResult = await sendPaymentV2Sync(
       paymentRequestStr,
       payload && payload.amount ? Long.fromValue(payload.amount) : undefined,
+      paymentRequest.numSatoshis,
       name,
       multiPathPaymentsEnabled,
     );


### PR DESCRIPTION
This PR targets an issue that affects Blixt 0.6 users. The intended logic for calculating the fee limit was correct, however mul() resulted in zero. Therefore, Math.max(10, amountTimesTwoPercent) would return 10 and set a fee ceiling for pathfinding. This negatively impacted Blixt users ability to transact.