### PR TITLE
Make LndMobileService run in the app process

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -96,8 +96,7 @@
 
       <service
         android:name=".LndMobileService"
-        android:exported="false"
-        android:process=":blixtLndMobile" />
+        android:exported="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Previously we explicitly spawned a separate process. But it seems like Android and/or different phone
vendors kill off the processes without also killing the app itself. The rule that a bound service cannot be killed without the host being killed as well does not seem to apply.