### PR TITLE
Subtract remote channel reserve from remote balance

### DIFF
--- a/src/components/ChannelCard.tsx
+++ b/src/components/ChannelCard.tsx
@@ -88,7 +88,12 @@ export function ChannelCard({ channel, alias }: IChannelCardProps) {
   else {
     localBalance = localBalance.sub(channel.localChanReserveSat!);
   }
-  const remoteBalance = channel.remoteBalance || Long.fromValue(0);
+  let remoteBalance = channel.remoteBalance || Long.fromValue(0);
+  if (remoteBalance.lessThanOrEqual(channel.remoteChanReserveSat!)) {
+    remoteBalance = Long.fromValue(0);
+  } else {
+    remoteBalance = remoteBalance.sub(channel.remoteChanReserveSat!);
+  }
   const percentageLocal = localBalance.mul(100).div(channel.capacity!).toNumber() / 100;
   const percentageRemote = remoteBalance.mul(100).div(channel.capacity!).toNumber() / 100;
   const percentageReverse = 1 - (percentageLocal + percentageRemote);


### PR DESCRIPTION
Partially solves https://github.com/hsjoberg/blixt-wallet/issues/1070

What this PR does is apply the same logic that is already applied to the "Can send" portion of the ChannelCard to the "Can receive" portion.

A full solution would add a line for "Remote reserve" in the UI.