### PR TITLE
Make LND unkillable

### DIFF
--- a/android/app/src/main/java/com/blixtwallet/LndMobile.java
+++ b/android/app/src/main/java/com/blixtwallet/LndMobile.java
@@ -268,9 +268,10 @@ class LndMobile extends ReactContextBaseJavaModule {
 
       lndMobileServiceConnection = new LndMobileServiceConnection(req);
       messenger = new Messenger(new IncomingHandler()); // me
-
+      Intent intent = new Intent(getReactApplicationContext(), LndMobileService.class);
+      getReactApplicationContext().startForegroundService(intent);
       getReactApplicationContext().bindService(
-        new Intent(getReactApplicationContext(), LndMobileService.class),
+        intent,
         lndMobileServiceConnection,
         Context.BIND_AUTO_CREATE
       );

--- a/android/app/src/main/java/com/blixtwallet/LndMobileService.java
+++ b/android/app/src/main/java/com/blixtwallet/LndMobileService.java
@@ -441,7 +441,7 @@ public class LndMobileService extends Service {
 
   @Override
   public int onStartCommand(Intent intent, int flags, int startid) {
-    HyperLog.v(TAG, "onStartCommand()")
+    HyperLog.v(TAG, "onStartCommand()");
     Intent notificationIntent = new Intent (this, MainActivity.class);
     PendingIntent pendingIntent =
       PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE);

--- a/android/app/src/main/java/com/blixtwallet/LndMobileService.java
+++ b/android/app/src/main/java/com/blixtwallet/LndMobileService.java
@@ -441,6 +441,7 @@ public class LndMobileService extends Service {
 
   @Override
   public int onStartCommand(Intent intent, int flags, int startid) {
+    HyperLog.v(TAG, "onStartCommand()")
     Intent notificationIntent = new Intent (this, MainActivity.class);
     PendingIntent pendingIntent =
       PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE);
@@ -458,7 +459,7 @@ public class LndMobileService extends Service {
         .setContentIntent(pendingIntent)
         .setTicker("Blixt Wallet")
         .build();
-      startForeground(ONGOING_NOTIFICATION_ID, notification);
+    startForeground(ONGOING_NOTIFICATION_ID, notification);
     return startid;
   }
 


### PR DESCRIPTION
By default, we are using a BoundService. The lifetime is defined for that as follows:

Blixt (foreground) -> minimized by user to home
Blixt now becomes cached process
Eventually, the cached main process is evicted due to its low priority
Because there are no more clients bound to the BoundService, it is unbinded and shutdown

This change enables LND to run as a Foreground Service so that even if the frontend is evicted by OOM killer, LND continues to run. This means users can accept payments and keep syncing gossip even while the app is backgrounded.

In addition, through some trickery the notification created is never shown to the user, keeping things clean. Users can always stop the Blixt service via the "active apps" menu in the slide-down menu in Android.