### PR TITLE
Fix newtor controlport and sockport, use cookieauth for tor

### DIFF
--- a/android/app/src/main/java/com/blixtwallet/BlixtTor.java
+++ b/android/app/src/main/java/com/blixtwallet/BlixtTor.java
@@ -28,7 +28,6 @@ public class BlixtTor extends ReactContextBaseJavaModule {
   static TorService torService;
   static String currentTorStatus = TorService.STATUS_OFF;
   static Stack<Promise> calleeResolvers = new Stack<>();
-  String fileStorageLocation;
 
   static private final ServiceConnection torServiceConnection = new ServiceConnection() {
     @Override
@@ -64,7 +63,6 @@ public class BlixtTor extends ReactContextBaseJavaModule {
 
   public BlixtTor(ReactApplicationContext reactContext) {
     super(reactContext);
-    fileStorageLocation = reactContext.getFilesDir().getPath() + "/torfiles";
   }
 
   public String getName() {
@@ -102,7 +100,8 @@ public class BlixtTor extends ReactContextBaseJavaModule {
     Intent intent = new Intent(getReactApplicationContext(), TorService.class);
     updateTorConfigCustom(TorService.getDefaultsTorrc(getReactApplicationContext()),
       "ControlPort " + BlixtTorUtils.getControlPort() + "\n" +
-      "SOCKSPort " + BlixtTorUtils.getSocksPort() + "\n");
+      "SOCKSPort " + BlixtTorUtils.getSocksPort() + "\n" + 
+      "CookieAuthentication 1" + "\n");
     getReactApplicationContext().bindService(intent, torServiceConnection, Context.BIND_AUTO_CREATE);
   }
 

--- a/android/app/src/main/java/com/blixtwallet/BlixtTorUtils.java
+++ b/android/app/src/main/java/com/blixtwallet/BlixtTorUtils.java
@@ -1,0 +1,38 @@
+package com.blixtwallet;
+
+import com.blixtwallet.BuildConfig;
+
+public class BlixtTorUtils {
+  public static int getSocksPort() {
+    int socksPort = 9070;
+    if (BuildConfig.CHAIN.equals("testnet")) {
+      socksPort += 10;
+    }
+    if (BuildConfig.DEBUG) {
+      socksPort += 100;
+    }
+    return socksPort;
+  }
+
+  public static int getControlPort() {
+    int controlPort = 9071;
+    if (BuildConfig.CHAIN.equals("testnet")) {
+      controlPort += 10;
+    }
+    if (BuildConfig.DEBUG) {
+      controlPort += 100;
+    }
+    return controlPort;
+  }
+
+  public static int getListenPort() {
+    int listenPort = 9760;
+    if (BuildConfig.CHAIN.equals("testnet")) {
+      listenPort += 10;
+    }
+    if (BuildConfig.DEBUG) {
+      listenPort += 100;
+    }
+    return listenPort;
+  }
+}

--- a/android/app/src/main/java/com/blixtwallet/LndMobile.java
+++ b/android/app/src/main/java/com/blixtwallet/LndMobile.java
@@ -333,9 +333,15 @@ class LndMobile extends ReactContextBaseJavaModule {
 
     Bundle bundle = new Bundle();
 
-    String params = "--nolisten --lnddir=" + getReactApplicationContext().getFilesDir().getPath() + " " + args;
+    String params = "--lnddir=" + getReactApplicationContext().getFilesDir().getPath();
     if (torEnabled) {
-      params += " --tor.active";
+      int listenPort = BlixtTorUtils.getListenPort();
+      int socksPort = BlixtTorUtils.getSocksPort();
+      int controlPort = BlixtTorUtils.getControlPort();
+      params += " --tor.active --tor.socks=127.0.0.1:" + socksPort + " --tor.control=127.0.0.1:" + controlPort;
+      params += " --tor.v3 --listen=localhost:" + listenPort;
+    } else {
+      params += " --nolisten";
     }
     bundle.putString(
       "args",

--- a/android/app/src/main/java/com/blixtwallet/LndMobileScheduledSyncWorker.java
+++ b/android/app/src/main/java/com/blixtwallet/LndMobileScheduledSyncWorker.java
@@ -393,8 +393,11 @@ public class LndMobileScheduledSyncWorker extends ListenableWorker {
     Bundle bundle = new Bundle();
     String params = "--lnddir=" + getApplicationContext().getFilesDir().getPath();
     if (torEnabled) {
-      HyperLog.d(TAG, "Adding Tor params for starting lnd, torSocksPort: " + torSocksPort);
-      params += " --tor.active --tor.socks=127.0.0.1:" + torSocksPort;
+      int socksPort = BlixtTorUtils.getSocksPort();
+      int controlPort = BlixtTorUtils.getControlPort();
+      HyperLog.d(TAG, "Adding Tor params for starting lnd, torSocksPort: " + socksPort + ", controlPort: " + controlPort);
+      params += " --tor.active --tor.socks=127.0.0.1:" + socksPort + " --tor.control=127.0.0.1:" + controlPort;
+      params += " --nolisten";
     }
     else {
       // If Tor isn't active, make sure we aren't


### PR DESCRIPTION
Fixes controlPort and socksPort by injecting a torrc into `TorService.java`

Also gets rid of `torServiceBound ` as discussed.