### PR TITLE
Hide forceClosePendingChannel in recovery mode

### DIFF
--- a/src/components/PendingChannelCard.tsx
+++ b/src/components/PendingChannelCard.tsx
@@ -17,6 +17,8 @@ import { useTranslation } from "react-i18next";
 import { namespaces } from "../i18n/i18n.constants";
 import { Alert } from "../utils/alert";
 
+const dataLossChannelState = 'ChanStatusLocalDataLoss|ChanStatusRestored';
+
 export interface IPendingChannelCardProps {
   type: "OPEN" | "CLOSING" | "FORCE_CLOSING" | "WAITING_CLOSE";
   channel: lnrpc.PendingChannelsResponse.IPendingOpenChannel
@@ -40,7 +42,34 @@ export const PendingChannelCard = ({ channel, type, alias }: IPendingChannelCard
     return (<Text>Error</Text>);
   }
 
+  const CheckForceCloseAbility = () => {
+    if (channel.channel?.chanStatusFlags === dataLossChannelState) {
+      return null;
+    }
+
+    const closingChannel = channel as lnrpc.PendingChannelsResponse.IWaitingCloseChannel;
+
+    if (!!closingChannel.closingTxid || closingChannel.closingTxid !== '') {
+      return null;
+    }
+
+    return (
+      <Row style={{ width: "100%" }}>
+      <Left>
+        <Button style={{ marginTop: 14 }} danger={true} small={true} onPress={() => forceClose(channel)}>
+          <Text style={{ fontSize: 8 }}>{t("channel.forceClosePendingChannel")}</Text>
+        </Button>
+      </Left>
+    </Row>
+    )
+  }
+
   const forceClose = (channel: lnrpc.PendingChannelsResponse.IWaitingCloseChannel) => {
+    if (channel.channel?.chanStatusFlags === dataLossChannelState) {
+      Alert.alert("Cannot Force Close A Channel In Recovery State");
+      return;
+    }
+
     if (!!channel.closingTxid || channel.closingTxid !== '') {
       Alert.alert("Closing Tx Has Already Been Broadcasted");
       return;
@@ -237,13 +266,7 @@ export const PendingChannelCard = ({ channel, type, alias }: IPendingChannelCard
                   </CopyText>
                 </Right>
               </Row>
-              <Row style={{ width: "100%" }}>
-                <Left>
-                  <Button style={{ marginTop: 14 }} danger={true} small={true} onPress={() => forceClose(channel)}>
-                  <Text style={{ fontSize: 8 }}>{t("channel.forceClosePendingChannel")}</Text>
-                  </Button>
-                </Left>
-              </Row>
+              <CheckForceCloseAbility />
             </>
           }
           {type === "FORCE_CLOSING" &&

--- a/src/components/PendingChannelCard.tsx
+++ b/src/components/PendingChannelCard.tsx
@@ -41,28 +41,9 @@ export const PendingChannelCard = ({ channel, type, alias }: IPendingChannelCard
   if (!channel.channel) {
     return (<Text>Error</Text>);
   }
+  const closingChannel = channel as lnrpc.PendingChannelsResponse.IWaitingCloseChannel;
 
-  const CheckForceCloseAbility = () => {
-    if (channel.channel?.chanStatusFlags === dataLossChannelState) {
-      return null;
-    }
-
-    const closingChannel = channel as lnrpc.PendingChannelsResponse.IWaitingCloseChannel;
-
-    if (!!closingChannel.closingTxid || closingChannel.closingTxid !== '') {
-      return null;
-    }
-
-    return (
-      <Row style={{ width: "100%" }}>
-      <Left>
-        <Button style={{ marginTop: 14 }} danger={true} small={true} onPress={() => forceClose(channel)}>
-          <Text style={{ fontSize: 8 }}>{t("channel.forceClosePendingChannel")}</Text>
-        </Button>
-      </Left>
-    </Row>
-    )
-  }
+  const isForceClosableChannel = (channel.channel?.chanStatusFlags === dataLossChannelState) || !!closingChannel.closingTxid ? false : true
 
   const forceClose = (channel: lnrpc.PendingChannelsResponse.IWaitingCloseChannel) => {
     if (channel.channel?.chanStatusFlags === dataLossChannelState) {
@@ -266,7 +247,17 @@ export const PendingChannelCard = ({ channel, type, alias }: IPendingChannelCard
                   </CopyText>
                 </Right>
               </Row>
-              <CheckForceCloseAbility />
+              {
+                isForceClosableChannel ? (
+                  <Row style={{ width: "100%" }}>
+                    <Left>
+                      <Button style={{ marginTop: 14 }} danger={true} small={true} onPress={() => forceClose(channel)}>
+                        <Text style={{ fontSize: 8 }}>{t("channel.forceClosePendingChannel")}</Text>
+                      </Button>
+                    </Left>
+                  </Row>
+                ) : null
+              }
             </>
           }
           {type === "FORCE_CLOSING" &&


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <niteshbalusu@icloud.com>

Fixes #1111

Hides the button that can forceclose a pending channel when a closing tx id is broadcasted or an SCB restore has been performed.