### PR TITLE
Implement basic hold invoice support

### DIFF
--- a/ios/LndMobile/Lnd.swift
+++ b/ios/LndMobile/Lnd.swift
@@ -129,6 +129,7 @@ open class Lnd {
     //
     "RouterSendPaymentV2": { req, cb in return LndmobileRouterSendPaymentV2(req, cb) },
     "SubscribeState": { req, cb in return LndmobileSubscribeState(req, cb) },
+    "RouterTrackPaymentV2": { req, cb in return LndmobileRouterTrackPaymentV2(req, cb) },
     // channel
     //
     "CloseChannel": { req, cb in return LndmobileCloseChannel(req, cb)},

--- a/src/components/LogBox.tsx
+++ b/src/components/LogBox.tsx
@@ -33,6 +33,7 @@ export default function LogBox(props: ILndLogBoxProps) {
         setScrollViewAtTheEnd(isCloseToBottom(nativeEvent));
       }}
       scrollEventThrottle={450}
+      removeClippedSubviews={true}
     >
       <Text selectable={true} style={{ fontSize: 10 }}>{props.text}</Text>
     </ScrollView>

--- a/src/components/TransactionCard.tsx
+++ b/src/components/TransactionCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StyleSheet, View, Image, Platform, PixelRatio } from "react-native";
 import { Body, Card, CardItem, Text, Right, Row } from "native-base";
+import Long from "long";
 
 import { fromUnixTime } from "date-fns";
 import { ITransaction } from "../storage/database/transaction";
@@ -63,6 +64,19 @@ export default function TransactionCard({ onPress, transaction, unit }: IProps) 
     }
   }
 
+  let statusLabel: string | undefined = undefined;
+  if (status !== "SETTLED") {
+    statusLabel = capitalize(status);
+    // Special case for pending payments ("pre-transactions")
+    if (
+      status === "OPEN" &&
+      Long.isLong(transaction.valueMsat) &&
+      transaction.valueMsat.isNegative()
+    ) {
+      statusLabel = "Pending";
+    }
+  }
+
   return (
     <Card>
       <CardItem activeOpacity={1} button={true} onPress={() => onPress(transaction.rHash)}>
@@ -105,7 +119,7 @@ export default function TransactionCard({ onPress, transaction, unit }: IProps) 
                 }
               </Text>
               <Text note={true} style={transactionStyle.status}>
-                {status !== "SETTLED" && capitalize(status)}
+                {statusLabel}
               </Text>
             </View>
           </View>

--- a/src/lndmobile/index.ts
+++ b/src/lndmobile/index.ts
@@ -219,7 +219,6 @@ export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, payAmou
   return new Promise(async (resolve, reject) => {
     const listener = LndMobileEventEmitter.addListener("RouterSendPaymentV2", (e) => {
       try {
-        listener.remove();
         const error = checkLndStreamErrorResponse("RouterSendPaymentV2", e);
         if (error === "EOF") {
           return;
@@ -229,7 +228,11 @@ export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, payAmou
         }
 
         const response = decodeSendPaymentV2Result(e.data);
-        resolve(response);
+
+        if (response.paymentRequest === paymentRequest) {
+          listener.remove();
+          resolve(response);
+        }
       } catch (error) {
         reject(error.message);
       }
@@ -251,6 +254,12 @@ export const decodeSendPaymentV2Result = (data: string): lnrpc.Payment => {
   });
 };
 
+export const decodeTrackPaymentV2Result = (data: string): lnrpc.Payment => {
+  return decodeStreamResult<lnrpc.Payment>({
+    response: lnrpc.Payment,
+    base64Result: data,
+  });
+};
 
 export const sendKeysendPaymentV2 = (destinationPubKey: string, sat: Long, preImage: Uint8Array, routeHints: lnrpc.IRouteHint[], tlvRecordNameStr: string, tlvRecordWhatSatMessageStr: string, maxLNFeePercentage: number = 3): Promise<lnrpc.Payment> => {
   const maxFeeRatio = (maxLNFeePercentage ?? 2) / 100;
@@ -612,6 +621,45 @@ export const getRecoveryInfo = async (): Promise<lnrpc.GetRecoveryInfoResponse> 
     options: {},
   });
   return response;
+};
+
+/**
+ * @throws
+ */
+ export const trackPaymentV2Sync = async (paymentHash: string): Promise<lnrpc.Payment> => {
+  const options: routerrpc.ITrackPaymentRequest = {
+    paymentHash: hexToUint8Array(paymentHash),
+    noInflightUpdates: true,
+  };
+
+  return new Promise(async (resolve, reject) => {
+    const listener = LndMobileEventEmitter.addListener("RouterTrackPaymentV2", (e) => {
+      try {
+        const error = checkLndStreamErrorResponse("RouterTrackPaymentV2", e);
+        if (error == "EOF") {
+          return;
+        } else if (error) {
+          console.log("Got error from RouterTrackPaymentV2", [error]);
+          return reject(error);
+        }
+
+        const response = decodeTrackPaymentV2Result(e.data);
+        // Only if we get an event that matches the original trackpayment request do we resolve the promise
+        if (response.paymentHash == paymentHash) {
+          resolve(response);
+          listener.remove();
+        }
+      } catch (error) {
+        reject(error.message);
+      }
+    });
+
+    const response = await sendStreamCommand<routerrpc.ITrackPaymentRequest, routerrpc.TrackPaymentRequest>({
+      request: routerrpc.TrackPaymentRequest,
+      method: "RouterTrackPaymentV2",
+      options,
+    }, false);
+  });
 };
 
 /**

--- a/src/lndmobile/index.ts
+++ b/src/lndmobile/index.ts
@@ -221,9 +221,11 @@ export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, payAmou
       try {
         const error = checkLndStreamErrorResponse("RouterSendPaymentV2", e);
         if (error === "EOF") {
+          listener.remove();
           return;
         } else if (error) {
           console.log("Got error from RouterSendPaymentV2", [error]);
+          listener.remove();
           return reject(error);
         }
 
@@ -304,8 +306,8 @@ export const sendKeysendPaymentV2 = (destinationPubKey: string, sat: Long, preIm
       const response = decodeSendPaymentV2Result(e.data);
       console.log(response);
 
-      resolve(response);
       listener.remove();
+      resolve(response);
     });
 
     const response = await sendStreamCommand<routerrpc.ISendPaymentRequest, routerrpc.SendPaymentRequest>({
@@ -637,17 +639,19 @@ export const getRecoveryInfo = async (): Promise<lnrpc.GetRecoveryInfoResponse> 
       try {
         const error = checkLndStreamErrorResponse("RouterTrackPaymentV2", e);
         if (error == "EOF") {
+          listener.remove();
           return;
         } else if (error) {
           console.log("Got error from RouterTrackPaymentV2", [error]);
+          listener.remove();
           return reject(error);
         }
 
         const response = decodeTrackPaymentV2Result(e.data);
         // Only if we get an event that matches the original trackpayment request do we resolve the promise
         if (response.paymentHash == paymentHash) {
-          resolve(response);
           listener.remove();
+          resolve(response);
         }
       } catch (error) {
         reject(error.message);

--- a/src/state/LndMobileInjection.ts
+++ b/src/state/LndMobileInjection.ts
@@ -20,6 +20,7 @@ import {
   getNodeInfo,
   getRecoveryInfo,
   initialize,
+  trackPaymentV2Sync,
   listPeers,
   listUnspent,
   lookupInvoice,
@@ -106,6 +107,7 @@ export interface ILndMobileInjections {
     getInfo: () => Promise<lnrpc.GetInfoResponse>;
     getNetworkInfo: () => Promise<lnrpc.NetworkInfo>;
     getNodeInfo: (pubKey: string) => Promise<lnrpc.NodeInfo>;
+    trackPaymentV2Sync: (rHash: string) => Promise<lnrpc.Payment>;
     lookupInvoice: (rHash: string) => Promise<lnrpc.Invoice>;
     listPeers: () => Promise<lnrpc.ListPeersResponse>;
     readLndLog: () => Promise<IReadLndLogResponse>;
@@ -229,6 +231,7 @@ export default {
     listUnspent,
     resetMissionControl,
     getNodeInfo,
+    trackPaymentV2Sync,
     getNetworkInfo,
     getInfo,
     lookupInvoice,

--- a/src/state/Transaction.ts
+++ b/src/state/Transaction.ts
@@ -117,45 +117,44 @@ export const transaction: ITransactionModel = {
       if (tx.status === "OPEN") {
         log.i("trackpayment tx", [tx.rHash]);
         if (tx.valueMsat.isNegative()) {
-          trackPayment(tx.rHash).then((trackPaymentResult) => {
-            log.i("trackpayment status", [trackPaymentResult.status, trackPaymentResult.paymentHash]);
-            if (trackPaymentResult.status === lnrpc.Payment.PaymentStatus.SUCCEEDED) {
-              log.i("trackpayment updating tx [settled]");
-              const updated: ITransaction = {
-                ...tx,
-                status: "SETTLED",
-                preimage: hexToUint8Array(trackPaymentResult.paymentPreimage),
-                hops: trackPaymentResult.htlcs[0].route?.hops?.map((hop) => ({
-                  chanId: hop.chanId ?? null,
-                  chanCapacity: hop.chanCapacity ?? null,
-                  amtToForward: hop.amtToForward || Long.fromInt(0),
-                  amtToForwardMsat: hop.amtToForwardMsat || Long.fromInt(0),
-                  fee: hop.fee || Long.fromInt(0),
-                  feeMsat: hop.feeMsat || Long.fromInt(0),
-                  expiry: hop.expiry || null,
-                  pubKey: hop.pubKey || null,
-                })) ?? [],
-              };
-              // tslint:disable-next-line
-              updateTransaction(db, updated).then(() => actions.updateTransaction({ transaction: updated }));
-            } else if (trackPaymentResult.status === lnrpc.Payment.PaymentStatus.UNKNOWN) {
-              log.i("trackpayment updating tx [unknown]");
-              const updated: ITransaction = {
-                ...tx,
-                status: "UNKNOWN",
-              };
-              // tslint:disable-next-line
-              updateTransaction(db, updated).then(() => actions.updateTransaction({ transaction: updated }));
-            } else if (trackPaymentResult.status === lnrpc.Payment.PaymentStatus.FAILED) {
-              log.i("trackpayment updating tx [failed]");
-              const updated: ITransaction = {
-                ...tx,
-                status: "CANCELED",
-              };
-              // tslint:disable-next-line
-              updateTransaction(db, updated).then(() => actions.updateTransaction({ transaction: updated }));
-            }
-          });
+        const trackPaymentResult = await trackPayment(tx.rHash);
+          log.i("trackpayment status", [trackPaymentResult.status, trackPaymentResult.paymentHash]);
+          if (trackPaymentResult.status === lnrpc.Payment.PaymentStatus.SUCCEEDED) {
+            log.i("trackpayment updating tx [settled]");
+            const updated: ITransaction = {
+              ...tx,
+              status: "SETTLED",
+              preimage: hexToUint8Array(trackPaymentResult.paymentPreimage),
+              hops: trackPaymentResult.htlcs[0].route?.hops?.map((hop) => ({
+                chanId: hop.chanId ?? null,
+                chanCapacity: hop.chanCapacity ?? null,
+                amtToForward: hop.amtToForward || Long.fromInt(0),
+                amtToForwardMsat: hop.amtToForwardMsat || Long.fromInt(0),
+                fee: hop.fee || Long.fromInt(0),
+                feeMsat: hop.feeMsat || Long.fromInt(0),
+                expiry: hop.expiry || null,
+                pubKey: hop.pubKey || null,
+              })) ?? [],
+            };
+            // tslint:disable-next-line
+            updateTransaction(db, updated).then(() => actions.updateTransaction({ transaction: updated }));
+          } else if (trackPaymentResult.status === lnrpc.Payment.PaymentStatus.UNKNOWN) {
+            log.i("trackpayment updating tx [unknown]");
+            const updated: ITransaction = {
+              ...tx,
+              status: "UNKNOWN",
+            };
+            // tslint:disable-next-line
+            updateTransaction(db, updated).then(() => actions.updateTransaction({ transaction: updated }));
+          } else if (trackPaymentResult.status === lnrpc.Payment.PaymentStatus.FAILED) {
+            log.i("trackpayment updating tx [failed]");
+            const updated: ITransaction = {
+              ...tx,
+              status: "CANCELED",
+            };
+            // tslint:disable-next-line
+            updateTransaction(db, updated).then(() => actions.updateTransaction({ transaction: updated }));
+          }
         } else {
           const check = await lookupInvoice(tx.rHash);
           if ((Date.now() / 1000) > (check.creationDate.add(check.expiry).toNumber())) {

--- a/src/windows/Send/SendConfirmation.tsx
+++ b/src/windows/Send/SendConfirmation.tsx
@@ -77,6 +77,7 @@ export default function SendConfirmation({ navigation, route }: ISendConfirmatio
         }
 
         getFeeEstimate();
+        setIsPaying(false);
       }
     }
 


### PR DESCRIPTION
what this PR does:
- insert a database entry (shell) before payment is started with status OPEN
- recovery code for when you initiated a HODL invoice payment but exited the app and then came back
(any number of HODL invoices!)

what this PR doesn't do:
- change to SendPaymentV2 stream (in other words, settlement happens the same way as before. once payment is settled, Blixt DB tx is updated properly)
- make concurrent hold payments possible (to do multiple hold invoices, you must exit the app and reopen it, resetting the UI state and allowing you to once again paste in an invoice to send. otherwise the pending state is shown forever)

demo video:
https://user-images.githubusercontent.com/3331929/236577742-52076ddc-14f9-45b1-97fb-0e9515d9b6d9.mp4
