### PR TITLE
Add ability to set outgoing channel id for paying an invoice

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -249,6 +249,9 @@
       },
       "feeEstimate": {
         "title": "Fee estimate"
+      },
+      "outgoingChannel": {
+        "title": "Select Outbound Channel"
       }
     }
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -251,7 +251,7 @@
         "title": "Fee estimate"
       },
       "outgoingChannel": {
-        "title": "Select Outbound Channel"
+        "title": "Outbound Channel"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@react-native-community/push-notification-ios": "^1.11.0",
     "@react-native-community/slider": "^4.4.2",
     "@react-native-google-signin/google-signin": "^10.0.1",
+    "@react-native-picker/picker": "^2.4.10",
     "@react-navigation/bottom-tabs": "^6.5.8",
     "@react-navigation/drawer": "7.0.0-alpha.2",
     "@react-navigation/native": "^6.1.7",

--- a/src/lndmobile/index.ts
+++ b/src/lndmobile/index.ts
@@ -46,13 +46,19 @@ export const writeConfigFile = async () => {
 };
 
 export const subscribeState = async () => {
-  const response = await sendStreamCommand<lnrpc.ISubscribeStateRequest, lnrpc.SubscribeStateRequest>({
-    request: lnrpc.SubscribeStateRequest,
-    method: "SubscribeState",
-    options: {},
-  }, false);
+  const response = await sendStreamCommand<
+    lnrpc.ISubscribeStateRequest,
+    lnrpc.SubscribeStateRequest
+  >(
+    {
+      request: lnrpc.SubscribeStateRequest,
+      method: "SubscribeState",
+      options: {},
+    },
+    false,
+  );
   return response;
-}
+};
 
 export const decodeState = (data: string): lnrpc.SubscribeStateResponse => {
   return decodeStreamResult<lnrpc.SubscribeStateResponse>({
@@ -64,16 +70,16 @@ export const decodeState = (data: string): lnrpc.SubscribeStateResponse => {
 /**
  * @throws
  */
-export const startLnd = async (torEnabled: boolean, args?: string): Promise<{data:string}> => {
+export const startLnd = async (torEnabled: boolean, args?: string): Promise<{ data: string }> => {
   return await LndMobile.startLnd(torEnabled, args);
 };
 
 /**
  * @throws
  */
-export const gossipSync = async (networkType: string): Promise<{ data: string } > => {
+export const gossipSync = async (networkType: string): Promise<{ data: string }> => {
   return await LndMobile.gossipSync(networkType);
-}
+};
 
 export const checkICloudEnabled = async (): Promise<boolean> => {
   return await LndMobileTools.checkICloudEnabled();
@@ -117,8 +123,15 @@ export const excludeLndICloudBackup = async () => {
 /**
  * @throws
  */
-export const connectPeer = async (pubkey: string, host: string): Promise<lnrpc.ConnectPeerResponse> => {
-  return await sendCommand<lnrpc.IConnectPeerRequest, lnrpc.ConnectPeerRequest, lnrpc.ConnectPeerResponse>({
+export const connectPeer = async (
+  pubkey: string,
+  host: string,
+): Promise<lnrpc.ConnectPeerResponse> => {
+  return await sendCommand<
+    lnrpc.IConnectPeerRequest,
+    lnrpc.ConnectPeerRequest,
+    lnrpc.ConnectPeerResponse
+  >({
     request: lnrpc.ConnectPeerRequest,
     response: lnrpc.ConnectPeerResponse,
     method: "ConnectPeer",
@@ -135,7 +148,11 @@ export const connectPeer = async (pubkey: string, host: string): Promise<lnrpc.C
  * @throws
  */
 export const disconnectPeer = async (pubKey: string): Promise<lnrpc.DisconnectPeerResponse> => {
-  const response = await sendCommand<lnrpc.IDisconnectPeerRequest, lnrpc.DisconnectPeerRequest, lnrpc.DisconnectPeerResponse>({
+  const response = await sendCommand<
+    lnrpc.IDisconnectPeerRequest,
+    lnrpc.DisconnectPeerRequest,
+    lnrpc.DisconnectPeerResponse
+  >({
     request: lnrpc.DisconnectPeerRequest,
     response: lnrpc.DisconnectPeerResponse,
     method: "DisconnectPeer",
@@ -149,16 +166,21 @@ export const disconnectPeer = async (pubKey: string): Promise<lnrpc.DisconnectPe
 /**
  * @throws
  */
-export const getNodeInfo = async (pubKey: string, includeChannels: boolean = false): Promise<lnrpc.NodeInfo> => {
-  const response = await sendCommand<lnrpc.INodeInfoRequest, lnrpc.NodeInfoRequest, lnrpc.NodeInfo>({
-    request: lnrpc.NodeInfoRequest,
-    response: lnrpc.NodeInfo,
-    method: "GetNodeInfo",
-    options: {
-      pubKey,
-      includeChannels,
+export const getNodeInfo = async (
+  pubKey: string,
+  includeChannels: boolean = false,
+): Promise<lnrpc.NodeInfo> => {
+  const response = await sendCommand<lnrpc.INodeInfoRequest, lnrpc.NodeInfoRequest, lnrpc.NodeInfo>(
+    {
+      request: lnrpc.NodeInfoRequest,
+      response: lnrpc.NodeInfo,
+      method: "GetNodeInfo",
+      options: {
+        pubKey,
+        includeChannels,
+      },
     },
-  });
+  );
   return response;
 };
 
@@ -166,7 +188,11 @@ export const getNodeInfo = async (pubKey: string, includeChannels: boolean = fal
  * @throws
  */
 export const getInfo = async (): Promise<lnrpc.GetInfoResponse> => {
-  const response = await sendCommand<lnrpc.IGetInfoRequest, lnrpc.GetInfoRequest, lnrpc.GetInfoResponse>({
+  const response = await sendCommand<
+    lnrpc.IGetInfoRequest,
+    lnrpc.GetInfoRequest,
+    lnrpc.GetInfoResponse
+  >({
     request: lnrpc.GetInfoRequest,
     response: lnrpc.GetInfoResponse,
     method: "GetInfo",
@@ -182,14 +208,18 @@ export const getInfo = async (): Promise<lnrpc.GetInfoResponse> => {
  * @params name TLV record for sender name
  *
  */
-export const sendPaymentSync = async (paymentRequest: string, amount?: Long, tlvRecordName?: string | null): Promise<lnrpc.SendResponse> => {
+export const sendPaymentSync = async (
+  paymentRequest: string,
+  amount?: Long,
+  tlvRecordName?: string | null,
+): Promise<lnrpc.SendResponse> => {
   const options: lnrpc.ISendRequest = {
     paymentRequest,
   };
   if (tlvRecordName && tlvRecordName.length > 0) {
     options.destCustomRecords = {
       [TLV_RECORD_NAME]: unicodeStringToUint8Array(tlvRecordName),
-    }
+    };
   }
   if (amount) {
     options.amt = amount;
@@ -204,8 +234,15 @@ export const sendPaymentSync = async (paymentRequest: string, amount?: Long, tlv
   return response;
 };
 
-
-export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, payAmount?: Long, tlvRecordName?: string | null, multiPath?: boolean, maxLNFeePercentage: number = 2): Promise<lnrpc.Payment> => {
+export const sendPaymentV2Sync = (
+  paymentRequest: string,
+  amount?: Long,
+  payAmount?: Long,
+  tlvRecordName?: string | null,
+  multiPath?: boolean,
+  maxLNFeePercentage: number = 2,
+  outgoingChanId?: Long,
+): Promise<lnrpc.Payment> => {
   const maxFeeRatio = (maxLNFeePercentage ?? 2) / 100;
 
   const options: routerrpc.ISendPaymentRequest = {
@@ -215,6 +252,7 @@ export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, payAmou
     maxParts: multiPath ? 16 : 1,
     feeLimitSat: Long.fromValue(Math.max(10, (payAmount?.toNumber() || 0) * maxFeeRatio)),
     cltvLimit: 0,
+    outgoingChanId,
   };
   if (amount) {
     options.amt = amount;
@@ -222,7 +260,7 @@ export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, payAmou
   if (tlvRecordName && tlvRecordName.length > 0) {
     options.destCustomRecords = {
       [TLV_RECORD_NAME]: unicodeStringToUint8Array(tlvRecordName),
-    }
+    };
   }
 
   return new Promise(async (resolve, reject) => {
@@ -249,11 +287,17 @@ export const sendPaymentV2Sync = (paymentRequest: string, amount?: Long, payAmou
       }
     });
 
-    const response = await sendStreamCommand<routerrpc.ISendPaymentRequest, routerrpc.SendPaymentRequest>({
-      request: routerrpc.SendPaymentRequest,
-      method: "RouterSendPaymentV2",
-      options,
-    }, false);
+    const response = await sendStreamCommand<
+      routerrpc.ISendPaymentRequest,
+      routerrpc.SendPaymentRequest
+    >(
+      {
+        request: routerrpc.SendPaymentRequest,
+        method: "RouterSendPaymentV2",
+        options,
+      },
+      false,
+    );
   });
 };
 
@@ -272,7 +316,15 @@ export const decodeTrackPaymentV2Result = (data: string): lnrpc.Payment => {
   });
 };
 
-export const sendKeysendPaymentV2 = (destinationPubKey: string, sat: Long, preImage: Uint8Array, routeHints: lnrpc.IRouteHint[], tlvRecordNameStr: string, tlvRecordWhatSatMessageStr: string, maxLNFeePercentage: number = 3): Promise<lnrpc.Payment> => {
+export const sendKeysendPaymentV2 = (
+  destinationPubKey: string,
+  sat: Long,
+  preImage: Uint8Array,
+  routeHints: lnrpc.IRouteHint[],
+  tlvRecordNameStr: string,
+  tlvRecordWhatSatMessageStr: string,
+  maxLNFeePercentage: number = 3,
+): Promise<lnrpc.Payment> => {
   const maxFeeRatio = (maxLNFeePercentage ?? 2) / 100;
 
   const options: routerrpc.ISendPaymentRequest = {
@@ -298,7 +350,9 @@ export const sendKeysendPaymentV2 = (destinationPubKey: string, sat: Long, preIm
     options.destCustomRecords![TLV_RECORD_NAME] = unicodeStringToUint8Array(tlvRecordNameStr);
   }
   if (tlvRecordWhatSatMessageStr && tlvRecordWhatSatMessageStr.length > 0) {
-    options.destCustomRecords![TLV_WHATSAT_MESSAGE] = unicodeStringToUint8Array(tlvRecordWhatSatMessageStr);
+    options.destCustomRecords![TLV_WHATSAT_MESSAGE] = unicodeStringToUint8Array(
+      tlvRecordWhatSatMessageStr,
+    );
   }
 
   return new Promise(async (resolve, reject) => {
@@ -319,18 +373,34 @@ export const sendKeysendPaymentV2 = (destinationPubKey: string, sat: Long, preIm
       resolve(response);
     });
 
-    const response = await sendStreamCommand<routerrpc.ISendPaymentRequest, routerrpc.SendPaymentRequest>({
-      request: routerrpc.SendPaymentRequest,
-      method: "RouterSendPaymentV2",
-      options,
-    }, false);
+    const response = await sendStreamCommand<
+      routerrpc.ISendPaymentRequest,
+      routerrpc.SendPaymentRequest
+    >(
+      {
+        request: routerrpc.SendPaymentRequest,
+        method: "RouterSendPaymentV2",
+        options,
+      },
+      false,
+    );
     console.log(response);
   });
 };
 
-export const sendKeysendPayment = async (destinationPubKey: string, sat: Long, preImage: Uint8Array, routeHints: lnrpc.IRouteHint[], tlvRecordNameStr: string): Promise<lnrpc.SendResponse> => {
+export const sendKeysendPayment = async (
+  destinationPubKey: string,
+  sat: Long,
+  preImage: Uint8Array,
+  routeHints: lnrpc.IRouteHint[],
+  tlvRecordNameStr: string,
+): Promise<lnrpc.SendResponse> => {
   try {
-    const responseQueryRoutes = await sendCommand<lnrpc.IQueryRoutesRequest, lnrpc.QueryRoutesRequest, lnrpc.QueryRoutesResponse>({
+    const responseQueryRoutes = await sendCommand<
+      lnrpc.IQueryRoutesRequest,
+      lnrpc.QueryRoutesRequest,
+      lnrpc.QueryRoutesResponse
+    >({
       request: lnrpc.QueryRoutesRequest,
       response: lnrpc.QueryRoutesResponse,
       method: "QueryRoutes",
@@ -341,7 +411,6 @@ export const sendKeysendPayment = async (destinationPubKey: string, sat: Long, p
         destCustomRecords: {
           // Custom records are injected in a hacky way below
           // because of a bug in protobufjs
-
           // [TLV_RECORD_NAME]: stringToUint8Array(tlvRecordNameStr),
           // 5482373484 is the record for lnd
           // keysend payments as described in
@@ -358,12 +427,17 @@ export const sendKeysendPayment = async (destinationPubKey: string, sat: Long, p
       try {
         const lastHop = route.hops!.length - 1;
 
-        route.hops![lastHop].customRecords!["5482373484"] =  preImage;
+        route.hops![lastHop].customRecords!["5482373484"] = preImage;
         if (tlvRecordNameStr && tlvRecordNameStr.length > 0) {
-          route.hops![lastHop].customRecords![TLV_RECORD_NAME] = stringToUint8Array(tlvRecordNameStr);
+          route.hops![lastHop].customRecords![TLV_RECORD_NAME] =
+            stringToUint8Array(tlvRecordNameStr);
         }
 
-        const response = await sendCommand<lnrpc.ISendToRouteRequest, lnrpc.SendToRouteRequest, lnrpc.SendResponse>({
+        const response = await sendCommand<
+          lnrpc.ISendToRouteRequest,
+          lnrpc.SendToRouteRequest,
+          lnrpc.SendResponse
+        >({
           request: lnrpc.SendToRouteRequest,
           response: lnrpc.SendResponse,
           method: "SendToRouteSync",
@@ -394,7 +468,11 @@ export const decodePaymentStatus = (data: string): routerrpc.PaymentStatus => {
 /**
  * @throws
  */
-export const addInvoice = async (amount: number, memo: string, expiry: number = 3600): Promise<lnrpc.AddInvoiceResponse> => {
+export const addInvoice = async (
+  amount: number,
+  memo: string,
+  expiry: number = 3600,
+): Promise<lnrpc.AddInvoiceResponse> => {
   const response = await sendCommand<lnrpc.IInvoice, lnrpc.Invoice, lnrpc.AddInvoiceResponse>({
     request: lnrpc.Invoice,
     response: lnrpc.AddInvoiceResponse,
@@ -426,8 +504,7 @@ export const getRouteHints = async (max: number = 5): Promise<lnrpc.IRouteHint[]
     let policy: lnrpc.IRoutingPolicy;
     if (remotePubkey === chanInfo.node1Pub) {
       policy = chanInfo.node1Policy!;
-    }
-    else {
+    } else {
       policy = chanInfo.node2Policy!;
     }
 
@@ -440,20 +517,26 @@ export const getRouteHints = async (max: number = 5): Promise<lnrpc.IRouteHint[]
       channelId = channel.peerScidAlias;
     }
 
-    routeHints.push(lnrpc.RouteHint.create({
-      hopHints: [{
-        nodeId: remotePubkey,
-        chanId: channelId,
-        feeBaseMsat: policy.feeBaseMsat ? policy.feeBaseMsat.toNumber() : 0,
-        feeProportionalMillionths: policy.feeRateMilliMsat ? policy.feeRateMilliMsat.toNumber() : 0,
-        cltvExpiryDelta: policy.timeLockDelta,
-      }]
-    }));
+    routeHints.push(
+      lnrpc.RouteHint.create({
+        hopHints: [
+          {
+            nodeId: remotePubkey,
+            chanId: channelId,
+            feeBaseMsat: policy.feeBaseMsat ? policy.feeBaseMsat.toNumber() : 0,
+            feeProportionalMillionths: policy.feeRateMilliMsat
+              ? policy.feeRateMilliMsat.toNumber()
+              : 0,
+            cltvExpiryDelta: policy.timeLockDelta,
+          },
+        ],
+      }),
+    );
   }
 
   console.log("our hints", routeHints);
   return routeHints;
-}
+};
 
 export interface IAddInvoiceBlixtLspArgs {
   amount: number;
@@ -471,7 +554,17 @@ export interface IAddInvoiceBlixtLspArgs {
 /**
  * @throws
  */
-export const addInvoiceBlixtLsp = async ({amount, memo, expiry = 600, servicePubkey, chanId, cltvExpiryDelta, feeBaseMsat, feeProportionalMillionths, preimage}: IAddInvoiceBlixtLspArgs): Promise<lnrpc.AddInvoiceResponse> => {
+export const addInvoiceBlixtLsp = async ({
+  amount,
+  memo,
+  expiry = 600,
+  servicePubkey,
+  chanId,
+  cltvExpiryDelta,
+  feeBaseMsat,
+  feeProportionalMillionths,
+  preimage,
+}: IAddInvoiceBlixtLspArgs): Promise<lnrpc.AddInvoiceResponse> => {
   const response = await sendCommand<lnrpc.IInvoice, lnrpc.Invoice, lnrpc.AddInvoiceResponse>({
     request: lnrpc.Invoice,
     response: lnrpc.AddInvoiceResponse,
@@ -482,13 +575,19 @@ export const addInvoiceBlixtLsp = async ({amount, memo, expiry = 600, servicePub
       memo,
       expiry: Long.fromValue(expiry),
       // private: true,
-      routeHints: [{hopHints: [{
-        nodeId: servicePubkey,
-        chanId: Long.fromString(chanId),
-        cltvExpiryDelta,
-        feeBaseMsat,
-        feeProportionalMillionths,
-      }]}],
+      routeHints: [
+        {
+          hopHints: [
+            {
+              nodeId: servicePubkey,
+              chanId: Long.fromString(chanId),
+              cltvExpiryDelta,
+              feeBaseMsat,
+              feeProportionalMillionths,
+            },
+          ],
+        },
+      ],
     },
   });
   return response;
@@ -497,8 +596,14 @@ export const addInvoiceBlixtLsp = async ({amount, memo, expiry = 600, servicePub
 /**
  * @throws
  */
-export const cancelInvoice = async (paymentHash: string): Promise<invoicesrpc.CancelInvoiceResp> => {
-  const response = await sendCommand<invoicesrpc.ICancelInvoiceMsg, invoicesrpc.CancelInvoiceMsg, invoicesrpc.CancelInvoiceResp>({
+export const cancelInvoice = async (
+  paymentHash: string,
+): Promise<invoicesrpc.CancelInvoiceResp> => {
+  const response = await sendCommand<
+    invoicesrpc.ICancelInvoiceMsg,
+    invoicesrpc.CancelInvoiceMsg,
+    invoicesrpc.CancelInvoiceResp
+  >({
     request: invoicesrpc.CancelInvoiceMsg,
     response: invoicesrpc.CancelInvoiceResp,
     method: "InvoicesCancelInvoice",
@@ -528,7 +633,11 @@ export const lookupInvoice = async (rHash: string): Promise<lnrpc.Invoice> => {
  * @throws
  */
 export const listPeers = async (): Promise<lnrpc.ListPeersResponse> => {
-  const response = await sendCommand<lnrpc.IListPeersRequest, lnrpc.ListPeersRequest, lnrpc.ListPeersResponse>({
+  const response = await sendCommand<
+    lnrpc.IListPeersRequest,
+    lnrpc.ListPeersRequest,
+    lnrpc.ListPeersResponse
+  >({
     request: lnrpc.ListPeersRequest,
     response: lnrpc.ListPeersResponse,
     method: "ListPeers",
@@ -540,8 +649,16 @@ export const listPeers = async (): Promise<lnrpc.ListPeersResponse> => {
 /**
  * @throws
  */
-export const queryRoutes = async (pubKey: string, amount?: Long, routeHints?: lnrpc.IRouteHint[]): Promise<lnrpc.QueryRoutesResponse> => {
-  const response = await sendCommand<lnrpc.IQueryRoutesRequest, lnrpc.IQueryRoutesRequest, lnrpc.QueryRoutesResponse>({
+export const queryRoutes = async (
+  pubKey: string,
+  amount?: Long,
+  routeHints?: lnrpc.IRouteHint[],
+): Promise<lnrpc.QueryRoutesResponse> => {
+  const response = await sendCommand<
+    lnrpc.IQueryRoutesRequest,
+    lnrpc.IQueryRoutesRequest,
+    lnrpc.QueryRoutesResponse
+  >({
     request: lnrpc.QueryRoutesRequest,
     response: lnrpc.QueryRoutesResponse,
     method: "QueryRoutes",
@@ -552,7 +669,7 @@ export const queryRoutes = async (pubKey: string, amount?: Long, routeHints?: ln
     },
   });
   return response;
-}
+};
 
 /**
  * @throws
@@ -573,7 +690,11 @@ export const decodePayReq = async (bolt11: string): Promise<lnrpc.PayReq> => {
  * @throws
  */
 export const describeGraph = async (): Promise<lnrpc.ChannelGraph> => {
-  const response = await sendCommand<lnrpc.IChannelGraphRequest, lnrpc.ChannelGraphRequest, lnrpc.ChannelGraph>({
+  const response = await sendCommand<
+    lnrpc.IChannelGraphRequest,
+    lnrpc.ChannelGraphRequest,
+    lnrpc.ChannelGraph
+  >({
     request: lnrpc.ChannelGraphRequest,
     response: lnrpc.ChannelGraph,
     method: "DescribeGraph",
@@ -586,7 +707,11 @@ export const describeGraph = async (): Promise<lnrpc.ChannelGraph> => {
  * @throws
  */
 export const getRecoveryInfo = async (): Promise<lnrpc.GetRecoveryInfoResponse> => {
-  const response = await sendCommand<lnrpc.IGetRecoveryInfoRequest, lnrpc.GetRecoveryInfoRequest, lnrpc.GetRecoveryInfoResponse>({
+  const response = await sendCommand<
+    lnrpc.IGetRecoveryInfoRequest,
+    lnrpc.GetRecoveryInfoRequest,
+    lnrpc.GetRecoveryInfoResponse
+  >({
     request: lnrpc.GetRecoveryInfoRequest,
     response: lnrpc.GetRecoveryInfoResponse,
     method: "GetRecoveryInfo",
@@ -598,8 +723,12 @@ export const getRecoveryInfo = async (): Promise<lnrpc.GetRecoveryInfoResponse> 
 /**
  * @throws
  */
- export const listUnspent = async (): Promise<lnrpc.ListUnspentResponse> => {
-  const response = await sendCommand<lnrpc.IListUnspentRequest, lnrpc.ListUnspentRequest, lnrpc.ListUnspentResponse>({
+export const listUnspent = async (): Promise<lnrpc.ListUnspentResponse> => {
+  const response = await sendCommand<
+    lnrpc.IListUnspentRequest,
+    lnrpc.ListUnspentRequest,
+    lnrpc.ListUnspentResponse
+  >({
     request: lnrpc.ListUnspentRequest,
     response: lnrpc.ListUnspentResponse,
     method: "WalletKitListUnspent",
@@ -611,8 +740,12 @@ export const getRecoveryInfo = async (): Promise<lnrpc.GetRecoveryInfoResponse> 
 /**
  * @throws
  */
- export const resetMissionControl = async (): Promise<routerrpc.ResetMissionControlResponse> => {
-  const response = await sendCommand<routerrpc.IResetMissionControlRequest, routerrpc.ResetMissionControlRequest, routerrpc.ResetMissionControlResponse>({
+export const resetMissionControl = async (): Promise<routerrpc.ResetMissionControlResponse> => {
+  const response = await sendCommand<
+    routerrpc.IResetMissionControlRequest,
+    routerrpc.ResetMissionControlRequest,
+    routerrpc.ResetMissionControlResponse
+  >({
     request: routerrpc.ResetMissionControlRequest,
     response: routerrpc.ResetMissionControlResponse,
     method: "RouterResetMissionControl",
@@ -624,8 +757,12 @@ export const getRecoveryInfo = async (): Promise<lnrpc.GetRecoveryInfoResponse> 
 /**
  * @throws
  */
- export const getNetworkInfo = async (): Promise<lnrpc.NetworkInfo> => {
-  const response = await sendCommand<lnrpc.INetworkInfoRequest, lnrpc.NetworkInfoRequest, lnrpc.NetworkInfo>({
+export const getNetworkInfo = async (): Promise<lnrpc.NetworkInfo> => {
+  const response = await sendCommand<
+    lnrpc.INetworkInfoRequest,
+    lnrpc.NetworkInfoRequest,
+    lnrpc.NetworkInfo
+  >({
     request: lnrpc.NetworkInfoRequest,
     response: lnrpc.NetworkInfo,
     method: "GetNetworkInfo",
@@ -637,7 +774,7 @@ export const getRecoveryInfo = async (): Promise<lnrpc.GetRecoveryInfoResponse> 
 /**
  * @throws
  */
- export const trackPaymentV2Sync = async (paymentHash: string): Promise<lnrpc.Payment> => {
+export const trackPaymentV2Sync = async (paymentHash: string): Promise<lnrpc.Payment> => {
   const options: routerrpc.ITrackPaymentRequest = {
     paymentHash: hexToUint8Array(paymentHash),
     noInflightUpdates: true,
@@ -667,19 +804,29 @@ export const getRecoveryInfo = async (): Promise<lnrpc.GetRecoveryInfoResponse> 
       }
     });
 
-    const response = await sendStreamCommand<routerrpc.ITrackPaymentRequest, routerrpc.TrackPaymentRequest>({
-      request: routerrpc.TrackPaymentRequest,
-      method: "RouterTrackPaymentV2",
-      options,
-    }, false);
+    const response = await sendStreamCommand<
+      routerrpc.ITrackPaymentRequest,
+      routerrpc.TrackPaymentRequest
+    >(
+      {
+        request: routerrpc.TrackPaymentRequest,
+        method: "RouterTrackPaymentV2",
+        options,
+      },
+      false,
+    );
   });
 };
 
 /**
  * @throws
  */
- export const listInvoices = async (): Promise<lnrpc.ListInvoiceResponse> => {
-  const response = await sendCommand<lnrpc.IListInvoiceRequest, lnrpc.ListInvoiceRequest, lnrpc.ListInvoiceResponse>({
+export const listInvoices = async (): Promise<lnrpc.ListInvoiceResponse> => {
+  const response = await sendCommand<
+    lnrpc.IListInvoiceRequest,
+    lnrpc.ListInvoiceRequest,
+    lnrpc.ListInvoiceResponse
+  >({
     request: lnrpc.ListInvoiceRequest,
     response: lnrpc.ListInvoiceResponse,
     method: "ListInvoices",

--- a/src/state/LndMobileInjection.ts
+++ b/src/state/LndMobileInjection.ts
@@ -1,7 +1,6 @@
 import {
   IAddInvoiceBlixtLspArgs,
   IReadLndLogResponse,
-  gossipSync,
   TEMP_moveLndToApplicationSupport,
   addInvoice,
   addInvoiceBlixtLsp,
@@ -20,8 +19,8 @@ import {
   getNetworkInfo,
   getNodeInfo,
   getRecoveryInfo,
+  gossipSync,
   initialize,
-  trackPaymentV2Sync,
   listPeers,
   listUnspent,
   lookupInvoice,
@@ -32,6 +31,7 @@ import {
   sendPaymentV2Sync,
   startLnd,
   subscribeState,
+  trackPaymentV2Sync,
   writeConfig,
   writeConfigFile,
 } from "../lndmobile/index";
@@ -50,6 +50,7 @@ import {
   pendingChannels,
   subscribeChannelEvents,
 } from "../lndmobile/channel";
+import { autopilotrpc, invoicesrpc, lnrpc, routerrpc, signrpc } from "../../proto/lightning";
 import {
   decodeInvoiceResult,
   deriveKey,
@@ -70,11 +71,11 @@ import {
   subscribeTransactions,
   walletBalance,
 } from "../lndmobile/onchain";
-import { status, modifyStatus, queryScores, setScores } from "../lndmobile/autopilot";
-import { checkScheduledSyncWorkStatus } from "../lndmobile/scheduled-sync"; // TODO(hsjoberg): This could be its own injection "LndMobileScheduledSync"
-import { checkScheduledGossipSyncWorkStatus } from "../lndmobile/scheduled-gossip-sync";
-import { lnrpc, signrpc, invoicesrpc, autopilotrpc, routerrpc } from "../../proto/lightning";
+import { modifyStatus, queryScores, setScores, status } from "../lndmobile/autopilot";
+
 import { WorkInfo } from "../lndmobile/LndMobile";
+import { checkScheduledGossipSyncWorkStatus } from "../lndmobile/scheduled-gossip-sync";
+import { checkScheduledSyncWorkStatus } from "../lndmobile/scheduled-sync"; // TODO(hsjoberg): This could be its own injection "LndMobileScheduledSync"
 
 export interface ILndMobileInjections {
   index: {
@@ -124,6 +125,7 @@ export interface ILndMobileInjections {
       tlvRecordName?: string | null,
       multiPath?: boolean,
       maxLNFeePercentage?: number,
+      outgoingChannelId?: Long,
     ) => Promise<lnrpc.Payment>;
     queryRoutes: (
       pubkey: string,

--- a/src/state/Send.ts
+++ b/src/state/Send.ts
@@ -1,24 +1,25 @@
-import { Action, action, Thunk, thunk } from "easy-peasy";
 import * as Bech32 from "bech32";
-import Long from "long";
 
-import { IStoreModel } from "./index";
-import { IStoreInjections } from "./store";
-import { ITransaction } from "../storage/database/transaction";
-import { lnrpc, routerrpc } from "../../proto/lightning";
-import { valueFiat } from "../utils/bitcoin-units";
-import { LnBech32Prefix } from "../utils/build";
+import { Action, Thunk, action, thunk } from "easy-peasy";
 import { getGeolocation, hexToUint8Array } from "../utils";
+import { lnrpc, routerrpc } from "../../proto/lightning";
+
 import { ILNUrlPayResponse } from "./LNURL";
-import { identifyService } from "../utils/lightning-services";
+import { IStoreInjections } from "./store";
+import { IStoreModel } from "./index";
+import { ITransaction } from "../storage/database/transaction";
+import { LnBech32Prefix } from "../utils/build";
+import Long from "long";
 import { PLATFORM } from "../utils/constants";
+import { identifyService } from "../utils/lightning-services";
+import logger from "./../utils/log";
+import { valueFiat } from "../utils/bitcoin-units";
 
 let ReactNativePermissions: any;
 if (PLATFORM !== "macos") {
   ReactNativePermissions = require("react-native-permissions");
 }
 
-import logger from "./../utils/log";
 const log = logger("Send");
 
 type PaymentRequest = string;
@@ -30,12 +31,13 @@ export interface ISendModelSetPaymentPayload {
 
 export interface IModelSendPaymentPayload {
   amount?: Long;
+  outgoingChannelId?: Long;
 }
 
 export interface IModelQueryRoutesPayload {
-  amount: Long,
-  pubKey: string,
-  routeHints?: lnrpc.IRouteHint[],
+  amount: Long;
+  pubKey: string;
+  routeHints?: lnrpc.IRouteHint[];
 }
 
 interface IExtraData {
@@ -50,9 +52,27 @@ interface IExtraData {
 
 export interface ISendModel {
   clear: Action<ISendModel>;
-  setPayment: Thunk<ISendModel, ISendModelSetPaymentPayload, IStoreInjections, {}, Promise<lnrpc.PayReq>>;
-  sendPayment: Thunk<ISendModel, IModelSendPaymentPayload | void, IStoreInjections, IStoreModel, Promise<lnrpc.Payment>>;
-  queryRoutesForFeeEstimate: Thunk<ISendModel, IModelQueryRoutesPayload, IStoreInjections, IStoreModel, Promise<lnrpc.QueryRoutesResponse>>;
+  setPayment: Thunk<
+    ISendModel,
+    ISendModelSetPaymentPayload,
+    IStoreInjections,
+    {},
+    Promise<lnrpc.PayReq>
+  >;
+  sendPayment: Thunk<
+    ISendModel,
+    IModelSendPaymentPayload | void,
+    IStoreInjections,
+    IStoreModel,
+    Promise<lnrpc.Payment>
+  >;
+  queryRoutesForFeeEstimate: Thunk<
+    ISendModel,
+    IModelQueryRoutesPayload,
+    IStoreInjections,
+    IStoreModel,
+    Promise<lnrpc.QueryRoutesResponse>
+  >;
 
   setPaymentRequestStr: Action<ISendModel, PaymentRequest>;
   setPaymentRequest: Action<ISendModel, lnrpc.PayReq>;
@@ -66,7 +86,7 @@ export interface ISendModel {
 }
 
 export const send: ISendModel = {
-  clear: action((state) =>  {
+  clear: action((state) => {
     state.paymentRequestStr = undefined;
     state.remoteNodeInfo = undefined;
     state.paymentRequest = undefined;
@@ -74,8 +94,8 @@ export const send: ISendModel = {
   }),
 
   queryRoutesForFeeEstimate: thunk(async (_, payload, { injections }) => {
-      const queryRoutes = injections.lndMobile.index.queryRoutes;
-      return await queryRoutes(payload.pubKey, payload.amount, payload.routeHints);
+    const queryRoutes = injections.lndMobile.index.queryRoutes;
+    return await queryRoutes(payload.pubKey, payload.amount, payload.routeHints);
   }),
 
   /**
@@ -111,7 +131,7 @@ export const send: ISendModel = {
     try {
       const nodeInfo = await getNodeInfo(paymentRequest.destination);
       actions.setRemoteNodeInfo(nodeInfo);
-    } catch (e) { }
+    } catch (e) {}
 
     return paymentRequest;
   }),
@@ -119,162 +139,191 @@ export const send: ISendModel = {
   /**
    * @throws
    */
-  sendPayment: thunk(async (_, payload, { getState, dispatch, injections, getStoreState, getStoreActions }) => {
-    const start = new Date().getTime();
+  sendPayment: thunk(
+    async (_, payload, { getState, dispatch, injections, getStoreState, getStoreActions }) => {
+      const start = new Date().getTime();
 
-    const sendPaymentV2Sync = injections.lndMobile.index.sendPaymentV2Sync;
-    const paymentRequestStr = getState().paymentRequestStr;
-    const paymentRequest = getState().paymentRequest;
-    const remoteNodeInfo = getState().remoteNodeInfo;
+      const sendPaymentV2Sync = injections.lndMobile.index.sendPaymentV2Sync;
+      const paymentRequestStr = getState().paymentRequestStr;
+      const paymentRequest = getState().paymentRequest;
+      const remoteNodeInfo = getState().remoteNodeInfo;
+      let outgoingChannelId = undefined;
 
-    if (paymentRequestStr === undefined || paymentRequest === undefined) {
-      throw new Error("Payment information missing");
-    }
+      if (paymentRequestStr === undefined || paymentRequest === undefined) {
+        throw new Error("Payment information missing");
+      }
 
-    // If this is a zero sum
-    // invoice, hack the value in
-    if (!paymentRequest.numSatoshis && payload && payload.amount) {
-      paymentRequest.numSatoshis = payload.amount;
-      paymentRequest.numMsat = payload.amount.mul(1000);
-    }
+      // If this is a zero sum
+      // invoice, hack the value in
+      if (!paymentRequest.numSatoshis && payload && payload.amount) {
+        paymentRequest.numSatoshis = payload.amount;
+        paymentRequest.numMsat = payload.amount.mul(1000);
+      }
 
-    const extraData: IExtraData = getState().extraData ?? {
-      payer: null,
-      type: "NORMAL",
-      website: null,
-      lnurlPayResponse: null,
-      lightningAddress: null,
-      lud16IdentifierMimeType: null,
-      lnurlPayTextPlain: null,
-    };
+      if (!!payload && !!payload.outgoingChannelId) {
+        outgoingChannelId = payload.outgoingChannelId;
+      }
 
-    const name = getStoreState().settings.name;
-    const multiPathPaymentsEnabled = getStoreState().settings.multiPathPaymentsEnabled;
-    const maxLNFeePercentage = getStoreState().settings.maxLNFeePercentage;
-    const getTransactionByPaymentRequest = getStoreState().transaction.getTransactionByPaymentRequest;
+      const extraData: IExtraData = getState().extraData ?? {
+        payer: null,
+        type: "NORMAL",
+        website: null,
+        lnurlPayResponse: null,
+        lightningAddress: null,
+        lud16IdentifierMimeType: null,
+        lnurlPayTextPlain: null,
+      };
 
-    // Pre-settlement tx insert
-    const preTransaction: ITransaction = getTransactionByPaymentRequest(paymentRequestStr) ?? {
-      date: paymentRequest.timestamp,
-      description: extraData.lnurlPayTextPlain ?? paymentRequest.description,
-      duration: 0,
-      expire: paymentRequest.expiry,
-      paymentRequest: paymentRequestStr,
-      remotePubkey: paymentRequest.destination,
-      rHash: paymentRequest.paymentHash,
-      status: "OPEN",
-      value: paymentRequest.numSatoshis.neg(),
-      valueMsat: paymentRequest.numSatoshis.neg().mul(1000),
-      amtPaidSat: paymentRequest.numSatoshis.neg(),
-      amtPaidMsat: paymentRequest.numSatoshis.neg().mul(1000),
-      fee: Long.fromInt(0),
-      feeMsat: Long.fromInt(0),
-      nodeAliasCached: (remoteNodeInfo && remoteNodeInfo.node && remoteNodeInfo.node.alias) || null,
-      payer: extraData.payer,
-      valueUSD: valueFiat(paymentRequest.numSatoshis, getStoreState().fiat.fiatRates.USD.last),
-      valueFiat: valueFiat(paymentRequest.numSatoshis, getStoreState().fiat.currentRate),
-      valueFiatCurrency: getStoreState().settings.fiatUnit,
-      locationLong: null,
-      locationLat: null,
-      tlvRecordName: null,
-      type: extraData.type,
-      website: extraData.website,
-      identifiedService: identifyService(paymentRequest.destination, paymentRequest.description, extraData.website),
-      //note: // TODO: Why wasn't this added
-      lightningAddress: extraData.lightningAddress ?? null,
-      lud16IdentifierMimeType: extraData.lud16IdentifierMimeType ?? null,
+      const name = getStoreState().settings.name;
+      const multiPathPaymentsEnabled = getStoreState().settings.multiPathPaymentsEnabled;
+      const maxLNFeePercentage = getStoreState().settings.maxLNFeePercentage;
+      const getTransactionByPaymentRequest =
+        getStoreState().transaction.getTransactionByPaymentRequest;
 
-      preimage: hexToUint8Array("0"),
-      lnurlPayResponse: extraData.lnurlPayResponse,
+      // Pre-settlement tx insert
+      const preTransaction: ITransaction = getTransactionByPaymentRequest(paymentRequestStr) ?? {
+        date: paymentRequest.timestamp,
+        description: extraData.lnurlPayTextPlain ?? paymentRequest.description,
+        duration: 0,
+        expire: paymentRequest.expiry,
+        paymentRequest: paymentRequestStr,
+        remotePubkey: paymentRequest.destination,
+        rHash: paymentRequest.paymentHash,
+        status: "OPEN",
+        value: paymentRequest.numSatoshis.neg(),
+        valueMsat: paymentRequest.numSatoshis.neg().mul(1000),
+        amtPaidSat: paymentRequest.numSatoshis.neg(),
+        amtPaidMsat: paymentRequest.numSatoshis.neg().mul(1000),
+        fee: Long.fromInt(0),
+        feeMsat: Long.fromInt(0),
+        nodeAliasCached:
+          (remoteNodeInfo && remoteNodeInfo.node && remoteNodeInfo.node.alias) || null,
+        payer: extraData.payer,
+        valueUSD: valueFiat(paymentRequest.numSatoshis, getStoreState().fiat.fiatRates.USD.last),
+        valueFiat: valueFiat(paymentRequest.numSatoshis, getStoreState().fiat.currentRate),
+        valueFiatCurrency: getStoreState().settings.fiatUnit,
+        locationLong: null,
+        locationLat: null,
+        tlvRecordName: null,
+        type: extraData.type,
+        website: extraData.website,
+        identifiedService: identifyService(
+          paymentRequest.destination,
+          paymentRequest.description,
+          extraData.website,
+        ),
+        //note: // TODO: Why wasn't this added
+        lightningAddress: extraData.lightningAddress ?? null,
+        lud16IdentifierMimeType: extraData.lud16IdentifierMimeType ?? null,
 
-      hops: [],
-    };
+        preimage: hexToUint8Array("0"),
+        lnurlPayResponse: extraData.lnurlPayResponse,
 
-    log.d("IPreTransaction", [preTransaction]);
-    await dispatch.transaction.syncTransaction(preTransaction);
+        hops: [],
+      };
 
-    let sendPaymentResult: lnrpc.Payment | undefined;
-    try {
-      sendPaymentResult = await sendPaymentV2Sync(
-        paymentRequestStr,
-        payload && payload.amount ? Long.fromValue(payload.amount) : undefined,
-        paymentRequest.numSatoshis,
-        name,
-        multiPathPaymentsEnabled,
-        maxLNFeePercentage,
-      );
-    } catch (error) {
-      await dispatch.transaction.syncTransaction({
-        ...preTransaction,
-        status: preTransaction.status === "SETTLED" ? preTransaction.status : "CANCELED",
-      });
-      throw error;
-    }
+      log.d("IPreTransaction", [preTransaction]);
+      await dispatch.transaction.syncTransaction(preTransaction);
 
-    log.i("status", [sendPaymentResult.status, sendPaymentResult.failureReason]);
-    if (sendPaymentResult.status !== lnrpc.Payment.PaymentStatus.SUCCEEDED) {
-      await dispatch.transaction.syncTransaction({
-        ...preTransaction,
-        status: "CANCELED",
-      });
-      throw new Error(`${translatePaymentFailureReason(sendPaymentResult.failureReason)}`);
-    }
-
-    const settlementDuration = (new Date().getTime() - start);
-
-    const transaction: ITransaction = {
-      ...preTransaction,
-      duration: settlementDuration,
-      status: "SETTLED",
-      fee: sendPaymentResult.fee || Long.fromInt(0),
-      feeMsat: sendPaymentResult.feeMsat || Long.fromInt(0),
-
-      preimage: hexToUint8Array(sendPaymentResult.paymentPreimage),
-
-      hops: sendPaymentResult.htlcs[0].route?.hops?.map((hop) => ({
-        chanId: hop.chanId ?? null,
-        chanCapacity: hop.chanCapacity ?? null,
-        amtToForward: hop.amtToForward || Long.fromInt(0),
-        amtToForwardMsat: hop.amtToForwardMsat || Long.fromInt(0),
-        fee: hop.fee || Long.fromInt(0),
-        feeMsat: hop.feeMsat || Long.fromInt(0),
-        expiry: hop.expiry || null,
-        pubKey: hop.pubKey || null,
-      })) ?? [],
-    };
-
-    log.d("ITransaction", [transaction]);
-    await dispatch.transaction.syncTransaction(transaction);
-
-    if (getStoreState().settings.transactionGeolocationEnabled) {
+      let sendPaymentResult: lnrpc.Payment | undefined;
       try {
-        log.d("Syncing geolocation for transaction");
-        if (PLATFORM === "ios") {
-          if (await ReactNativePermissions.check(ReactNativePermissions.PERMISSIONS.IOS.LOCATION_WHEN_IN_USE) === "denied") {
-            log.d("Requesting geolocation permission");
-            const r = await ReactNativePermissions.request(ReactNativePermissions.PERMISSIONS.IOS.LOCATION_WHEN_IN_USE);
-            if (r !== "granted") {
-              throw new Error(`Got "${r}" when requesting Geolocation permission`);
+        sendPaymentResult = await sendPaymentV2Sync(
+          paymentRequestStr,
+          payload && payload.amount ? Long.fromValue(payload.amount) : undefined,
+          paymentRequest.numSatoshis,
+          name,
+          multiPathPaymentsEnabled,
+          maxLNFeePercentage,
+          outgoingChannelId,
+        );
+      } catch (error) {
+        await dispatch.transaction.syncTransaction({
+          ...preTransaction,
+          status: preTransaction.status === "SETTLED" ? preTransaction.status : "CANCELED",
+        });
+        throw error;
+      }
+
+      log.i("status", [sendPaymentResult.status, sendPaymentResult.failureReason]);
+      if (sendPaymentResult.status !== lnrpc.Payment.PaymentStatus.SUCCEEDED) {
+        await dispatch.transaction.syncTransaction({
+          ...preTransaction,
+          status: "CANCELED",
+        });
+        throw new Error(`${translatePaymentFailureReason(sendPaymentResult.failureReason)}`);
+      }
+
+      const settlementDuration = new Date().getTime() - start;
+
+      const transaction: ITransaction = {
+        ...preTransaction,
+        duration: settlementDuration,
+        status: "SETTLED",
+        fee: sendPaymentResult.fee || Long.fromInt(0),
+        feeMsat: sendPaymentResult.feeMsat || Long.fromInt(0),
+
+        preimage: hexToUint8Array(sendPaymentResult.paymentPreimage),
+
+        hops:
+          sendPaymentResult.htlcs[0].route?.hops?.map((hop) => ({
+            chanId: hop.chanId ?? null,
+            chanCapacity: hop.chanCapacity ?? null,
+            amtToForward: hop.amtToForward || Long.fromInt(0),
+            amtToForwardMsat: hop.amtToForwardMsat || Long.fromInt(0),
+            fee: hop.fee || Long.fromInt(0),
+            feeMsat: hop.feeMsat || Long.fromInt(0),
+            expiry: hop.expiry || null,
+            pubKey: hop.pubKey || null,
+          })) ?? [],
+      };
+
+      log.d("ITransaction", [transaction]);
+      await dispatch.transaction.syncTransaction(transaction);
+
+      if (getStoreState().settings.transactionGeolocationEnabled) {
+        try {
+          log.d("Syncing geolocation for transaction");
+          if (PLATFORM === "ios") {
+            if (
+              (await ReactNativePermissions.check(
+                ReactNativePermissions.PERMISSIONS.IOS.LOCATION_WHEN_IN_USE,
+              )) === "denied"
+            ) {
+              log.d("Requesting geolocation permission");
+              const r = await ReactNativePermissions.request(
+                ReactNativePermissions.PERMISSIONS.IOS.LOCATION_WHEN_IN_USE,
+              );
+              if (r !== "granted") {
+                throw new Error(`Got "${r}" when requesting Geolocation permission`);
+              }
             }
           }
+
+          const coords = await getGeolocation();
+          transaction.locationLong = coords.longitude;
+          transaction.locationLat = coords.latitude;
+          await dispatch.transaction.syncTransaction(transaction);
+        } catch (error) {
+          log.i(`Error getting geolocation for transaction: ${JSON.stringify(error)}`, [error]);
         }
-
-        const coords = await getGeolocation();
-        transaction.locationLong = coords.longitude;
-        transaction.locationLat = coords.latitude;
-        await dispatch.transaction.syncTransaction(transaction);
-      } catch (error) {
-        log.i(`Error getting geolocation for transaction: ${JSON.stringify(error)}`, [error]);
       }
-    }
 
-    return sendPaymentResult;
+      return sendPaymentResult;
+    },
+  ),
+
+  setPaymentRequestStr: action((state, payload) => {
+    state.paymentRequestStr = payload;
   }),
-
-  setPaymentRequestStr: action((state, payload) => { state.paymentRequestStr = payload; }),
-  setPaymentRequest: action((state, payload) => { state.paymentRequest = payload; }),
-  setRemoteNodeInfo: action((state, payload) => { state.remoteNodeInfo = payload; }),
-  setExtraData: action((state, payload) => { state.extraData = payload; }),
+  setPaymentRequest: action((state, payload) => {
+    state.paymentRequest = payload;
+  }),
+  setRemoteNodeInfo: action((state, payload) => {
+    state.remoteNodeInfo = payload;
+  }),
+  setExtraData: action((state, payload) => {
+    state.extraData = payload;
+  }),
 };
 
 const checkBech32 = (bech32: string, prefix: string): boolean => {
@@ -288,21 +337,16 @@ const checkBech32 = (bech32: string, prefix: string): boolean => {
 export const translatePaymentFailureReason = (reason: lnrpc.PaymentFailureReason) => {
   if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_NONE) {
     throw new Error("Payment failed");
-  }
-  else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_TIMEOUT) {
+  } else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_TIMEOUT) {
     return "Payment timed out";
-  }
-  else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_NO_ROUTE) {
+  } else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_NO_ROUTE) {
     return "Could not find route to recipient";
-  }
-  else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_ERROR) {
+  } else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_ERROR) {
     return "The payment failed to proceed";
-  }
-  else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_INCORRECT_PAYMENT_DETAILS) {
+  } else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_INCORRECT_PAYMENT_DETAILS) {
     return "Incorrect payment details provided";
-  }
-  else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_INSUFFICIENT_BALANCE) {
+  } else if (reason === lnrpc.PaymentFailureReason.FAILURE_REASON_INSUFFICIENT_BALANCE) {
     return "Insufficient balance";
   }
   return "Unknown error";
-}
+};

--- a/src/windows/Send/SendConfirmation.tsx
+++ b/src/windows/Send/SendConfirmation.tsx
@@ -9,7 +9,6 @@ import { useStoreActions, useStoreState } from "../../state/store";
 import Input from "../../components/Input";
 import Long from "long";
 import { PLATFORM } from "../../utils/constants";
-// import { Picker } from "@react-native-picker/picker";
 import { RouteProp } from "@react-navigation/native";
 import { SendStackParamList } from "./index";
 import { StackNavigationProp } from "@react-navigation/stack";

--- a/src/windows/Send/SendConfirmation.tsx
+++ b/src/windows/Send/SendConfirmation.tsx
@@ -1,4 +1,4 @@
-import { BackHandler, Keyboard, Vibration } from "react-native";
+import { BackHandler, Keyboard, StyleSheet, Vibration } from "react-native";
 import { BitcoinUnits, unitToSatoshi } from "../../utils/bitcoin-units";
 import BlixtForm, { IFormItem } from "../../components/Form";
 import { Button, Container, Icon, Picker, Spinner, Text } from "native-base";
@@ -265,13 +265,13 @@ export default function SendConfirmation({ navigation, route }: ISendConfirmatio
         <Picker
           note
           mode="dropdown"
-          style={{ width: 120 }}
+          style={styles.pickerStyle}
           selectedValue={outChannel}
           onValueChange={(n: Long) => setOutChannel(n)}
         >
-          <Picker.Item label="--None--" value="" />
+          <Picker.Item style={styles.itemStyle} label="--None--" value="" />
           {getChannels.map((n, i) => (
-            <Picker.Item label={choiceLabel(n)} key={i} value={n.chanId} />
+            <Picker.Item style={styles.itemStyle} label={choiceLabel(n)} key={i} value={n.chanId} />
           ))}
         </Picker>
       ),
@@ -306,3 +306,20 @@ export default function SendConfirmation({ navigation, route }: ISendConfirmatio
     </Container>
   );
 }
+
+// Add this at the end of your component file
+const styles = StyleSheet.create({
+  pickerStyle: {
+    width: 120,
+    backgroundColor: "#3f3f3f", // Dark gray
+    borderColor: "#ffffff", // White
+    borderWidth: 1,
+    borderRadius: 5,
+    color: "#ffffff", // White color for text
+  },
+  itemStyle: {
+    backgroundColor: "#1f1f1f", // Even darker gray
+    padding: 10,
+    color: "#ffffff", // White color for text
+  },
+});

--- a/src/windows/Send/SendConfirmation.tsx
+++ b/src/windows/Send/SendConfirmation.tsx
@@ -269,7 +269,7 @@ export default function SendConfirmation({ navigation, route }: ISendConfirmatio
           selectedValue={outChannel}
           onValueChange={(n: Long) => setOutChannel(n)}
         >
-          <Picker.Item style={styles.itemStyle} label="--None--" value="" />
+          <Picker.Item style={styles.itemStyle} label="--Any--" value="" />
           {getChannels.map((n, i) => (
             <Picker.Item style={styles.itemStyle} label={choiceLabel(n)} key={i} value={n.chanId} />
           ))}
@@ -307,19 +307,18 @@ export default function SendConfirmation({ navigation, route }: ISendConfirmatio
   );
 }
 
-// Add this at the end of your component file
 const styles = StyleSheet.create({
   pickerStyle: {
     width: 120,
-    backgroundColor: "#3f3f3f", // Dark gray
-    borderColor: "#ffffff", // White
+    backgroundColor: blixtTheme.gray, 
+    borderColor: blixtTheme.light, 
     borderWidth: 1,
     borderRadius: 5,
-    color: "#ffffff", // White color for text
+    color: blixtTheme.light, 
   },
   itemStyle: {
-    backgroundColor: "#1f1f1f", // Even darker gray
+    backgroundColor: blixtTheme.gray, 
     padding: 10,
-    color: "#ffffff", // White color for text
+    color: blixtTheme.light,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2701,6 +2701,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-1.16.8.tgz#2126ca54d4a5a3e9ea5e3f39ad1e6643f8e4b3d4"
   integrity sha512-pacdQDX6V6EmjF+HoiIh6u++qx4mTK0WnhgUHRc01B+Qt5eoeUwseBqmqfTSXTx/aHDEd6PiIw7UGvKgFoqgFQ==
 
+"@react-native-picker/picker@^2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.10.tgz#339c7bfc6e1d9a5e934122eaaa7767dc1c5fb725"
+  integrity sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==
+
 "@react-native/assets-registry@^0.72.0":
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.72.0.tgz#c82a76a1d86ec0c3907be76f7faf97a32bbed05d"


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <84944042+niteshbalusu11@users.noreply.github.com>

Drop down picker in the SendConfirmation screen that lists your channels you can pay out of with liquidity numbers.