### PR TITLE
Make blixt node default zero conf peer

### DIFF
--- a/src/state/Settings.ts
+++ b/src/state/Settings.ts
@@ -1,5 +1,6 @@
 import { Action, Thunk, action, thunk } from "easy-peasy";
 import {
+  BLIXT_NODE_PUBKEY,
   DEFAULT_INVOICE_EXPIRY,
   DEFAULT_LND_LOG_LEVEL,
   DEFAULT_MAX_LN_FEE_PERCENTAGE,
@@ -215,7 +216,7 @@ export const settings: ISettingsModel = {
     actions.setICloudBackupEnabled(await getItemObject(StorageItem.iCloudBackupEnabled ?? false));
     actions.setLndChainBackend((await getItem(StorageItem.lndChainBackend)) ?? "");
     actions.setNeutrinoPeers((await getItemObject(StorageItem.neutrinoPeers)) ?? []);
-    actions.setZeroConfPeers((await getItemObject(StorageItem.zeroConfPeers)) ?? []);
+    actions.setZeroConfPeers((await getItemObject(StorageItem.zeroConfPeers)) ?? [BLIXT_NODE_PUBKEY]);
     actions.setBitcoindRpcHost((await getItem(StorageItem.bitcoindRpcHost)) ?? "");
     actions.setBitcoindPubRawBlock((await getItem(StorageItem.bitcoindPubRawBlock)) ?? "");
     actions.setBitcoindPubRawTx((await getItem(StorageItem.bitcoindPubRawTx)) ?? "");

--- a/src/storage/app.ts
+++ b/src/storage/app.ts
@@ -1,5 +1,5 @@
-import { Chain, Debug, VersionCode } from "../utils/build";
 import {
+  BLIXT_NODE_PUBKEY,
   DEFAULT_DUNDER_SERVER,
   DEFAULT_INVOICE_EXPIRY,
   DEFAULT_LND_LOG_LEVEL,
@@ -8,6 +8,7 @@ import {
   DEFAULT_PATHFINDING_ALGORITHM,
   PLATFORM,
 } from "../utils/constants";
+import { Chain, Debug, VersionCode } from "../utils/build";
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { IBitcoinUnits } from "../utils/bitcoin-units";
@@ -270,5 +271,6 @@ export const setupApp = async () => {
     setItemObject<boolean>(StorageItem.enforceSpeedloaderOnStartup, false),
     setItemObject<boolean>(StorageItem.persistentServicesEnabled, false),
     setItemObject<boolean>(StorageItem.persistentServicesWarningShown, false),
+    setItemObject<string[]>(StorageItem.zeroConfPeers, [BLIXT_NODE_PUBKEY])
   ]);
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,8 +1,9 @@
 import { Platform, StatusBar } from "react-native";
-import { getStatusBarHeight } from "react-native-status-bar-height";
-import { LndLogLevel } from "../state/Settings";
+
 import { Chain } from "./build";
+import { LndLogLevel } from "../state/Settings";
 import { chainSelect } from "./chain-select";
+import { getStatusBarHeight } from "react-native-status-bar-height";
 import { zoomed } from "./scale";
 
 export const TLV_RECORD_NAME = 128101;
@@ -45,3 +46,6 @@ export const HEADER_MAX_HEIGHT = (Platform.select({
   web: 195 - 32,
   macos: 175
 }) ?? 195) / (zoomed ? 0.85 : 1);
+
+
+export const BLIXT_NODE_PUBKEY = "0230a5bca558e6741460c13dd34e636da28e52afd91cf93db87ed1b0392a7466eb";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,7 +19,8 @@ export const PLATFORM = Platform.OS;
 
 export const MATH_PAD_NATIVE_ID = "MATH_PAD";
 
-export const DEFAULT_NEUTRINO_NODE = Chain === "mainnet" ? "node.blixtwallet.com" : "testnet.blixtwallet.com";
+export const DEFAULT_NEUTRINO_NODE =
+  Chain === "mainnet" ? "node.blixtwallet.com" : "testnet.blixtwallet.com";
 export const DEFAULT_INVOICE_EXPIRY = 3600;
 export const DEFAULT_MAX_LN_FEE_PERCENTAGE = 2;
 export const DEFAULT_LND_LOG_LEVEL: LndLogLevel = "info";
@@ -34,18 +35,22 @@ export const DEFAULT_DUNDER_SERVER = chainSelect({
   regtest: "http://192.168.1.111:8080",
 });
 
-export const HEADER_MIN_HEIGHT = Platform.select({
-  android: (StatusBar.currentHeight ?? 0) + 53,
-  ios: getStatusBarHeight(true) + 53,
-  macos: 53
-}) ?? 53;
+export const HEADER_MIN_HEIGHT =
+  Platform.select({
+    android: (StatusBar.currentHeight ?? 0) + 53,
+    ios: getStatusBarHeight(true) + 53,
+    macos: 53,
+  }) ?? 53;
 
-export const HEADER_MAX_HEIGHT = (Platform.select({
-  android: 195,
-  ios: 195,
-  web: 195 - 32,
-  macos: 175
-}) ?? 195) / (zoomed ? 0.85 : 1);
+export const HEADER_MAX_HEIGHT =
+  (Platform.select({
+    android: 195,
+    ios: 195,
+    web: 195 - 32,
+    macos: 175,
+  }) ?? 195) / (zoomed ? 0.85 : 1);
 
-
-export const BLIXT_NODE_PUBKEY = "0230a5bca558e6741460c13dd34e636da28e52afd91cf93db87ed1b0392a7466eb";
+export const BLIXT_NODE_PUBKEY =
+  Chain === "mainnet"
+    ? "0230a5bca558e6741460c13dd34e636da28e52afd91cf93db87ed1b0392a7466eb"
+    : "036b7130b27a23d6fe1d55c1d3bed9e6da5a17090588b0834e8200e0d50ee6886a";


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <84944042+niteshbalusu11@users.noreply.github.com>

If storage item is empty, default to blixt node as zero conf peer.