### PR TITLE
Reject legacy channels by default

### DIFF
--- a/src/state/ChannelAcceptanceManager.ts
+++ b/src/state/ChannelAcceptanceManager.ts
@@ -46,6 +46,8 @@ export const channelAcceptanceManager: IChannelAcceptanceManagerModel = {
             channelAcceptRequest.pendingChanId,
             false,
           );
+          
+          log.i("Channel request rejected", channelAcceptRequest.commitmentType);
           return;
         }
 

--- a/src/state/ChannelAcceptanceManager.ts
+++ b/src/state/ChannelAcceptanceManager.ts
@@ -47,7 +47,7 @@ export const channelAcceptanceManager: IChannelAcceptanceManagerModel = {
             false,
           );
           
-          log.i("Channel request rejected", channelAcceptRequest.commitmentType);
+          log.i("Channel request rejected due to commitment type: ", [channelAcceptRequest.commitmentType]);
           return;
         }
 

--- a/src/windows/LightningInfo/OpenChannel.tsx
+++ b/src/windows/LightningInfo/OpenChannel.tsx
@@ -67,14 +67,14 @@ export default function OpenChannel({ navigation, route }: IOpenChannelProps) {
         await connectAndOpenChannelAll({
           peer,
           feeRateSat: feeRate !== 0 ? feeRate : undefined,
-          type: taprootChan ? lnrpc.CommitmentType["SIMPLE_TAPROOT"] : undefined,
+          type: taprootChan ? lnrpc.CommitmentType["SIMPLE_TAPROOT"] : lnrpc.CommitmentType.ANCHORS,
         });
       } else {
         await connectAndOpenChannel({
           peer,
           amount: satoshiValue,
           feeRateSat: feeRate !== 0 ? feeRate : undefined,
-          type: taprootChan ? lnrpc.CommitmentType["SIMPLE_TAPROOT"] : undefined,
+          type: taprootChan ? lnrpc.CommitmentType["SIMPLE_TAPROOT"] : lnrpc.CommitmentType.ANCHORS,
         });
       }
       await getChannels(undefined);
@@ -88,35 +88,31 @@ export default function OpenChannel({ navigation, route }: IOpenChannelProps) {
         (torEnabled && error.message?.includes(".onion: no such host")) ||
         error.message?.includes(".onion: No address associated with hostname")
       ) {
-        await Alert.alert(
-          t("torPrompt.title"),
-          t("torPrompt.text1") + "\n\n" + t("torPrompt.text2"),
-          [
-            {
-              text: "Cancel",
-            },
-            {
-              text: "Activate Tor",
-              async onPress(value?) {
-                await changeTorEnabled(!torEnabled);
-                if (PLATFORM === "android") {
-                  try {
-                    await NativeModules.LndMobile.stopLnd();
-                    await NativeModules.LndMobileTools.killLnd();
-                  } catch (e) {
-                    console.log(e);
-                  }
-                  NativeModules.LndMobileTools.restartApp();
-                } else {
-                  Alert.alert(
-                    t("bitcoinNetwork.restartDialog.title", { ns: namespaces.settings.settings }),
-                    t("bitcoinNetwork.restartDialog.msg", { ns: namespaces.settings.settings }),
-                  );
+        Alert.alert(t("torPrompt.title"), t("torPrompt.text1") + "\n\n" + t("torPrompt.text2"), [
+          {
+            text: "Cancel",
+          },
+          {
+            text: "Activate Tor",
+            async onPress(value?) {
+              await changeTorEnabled(!torEnabled);
+              if (PLATFORM === "android") {
+                try {
+                  await NativeModules.LndMobile.stopLnd();
+                  await NativeModules.LndMobileTools.killLnd();
+                } catch (e) {
+                  console.log(e);
                 }
-              },
+                NativeModules.LndMobileTools.restartApp();
+              } else {
+                Alert.alert(
+                  t("bitcoinNetwork.restartDialog.title", { ns: namespaces.settings.settings }),
+                  t("bitcoinNetwork.restartDialog.msg", { ns: namespaces.settings.settings }),
+                );
+              }
             },
-          ],
-        );
+          },
+        ]);
       }
     }
   };


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <84944042+niteshbalusu11@users.noreply.github.com>

Reject unknown, legacy and static remote key channels and explicitly set anchors commitment type for outbound channels.