### PR TITLE
Add mainnet neutrino peers

### DIFF
--- a/src/migration/app-migration.ts
+++ b/src/migration/app-migration.ts
@@ -343,10 +343,12 @@ export const appMigration: IAppMigration[] = [
   // Version 39
   {
     async beforeLnd(db, i) {
-      if (Chain === "testnet" || Chain === "mainnet") {
-        const neutrinoPeers = DEFAULT_NEUTRINO_NODE?.split(",");
-
-        await setItemObject<string[]>(StorageItem.neutrinoPeers, neutrinoPeers || []);
+      if (Chain === "mainnet") {
+        // Change the peers if the user hasn't manually changed it
+        const peers = await getItemObject<string[]>(StorageItem.neutrinoPeers);
+        if (peers.length === 1 && peers[0] === "node.blixtwallet.com") {
+          await setItemObject<string[]>(StorageItem.neutrinoPeers, DEFAULT_NEUTRINO_NODE);
+        }
       }
     },
   },

--- a/src/migration/app-migration.ts
+++ b/src/migration/app-migration.ts
@@ -340,4 +340,14 @@ export const appMigration: IAppMigration[] = [
       await db.executeSql("ALTER TABLE tx ADD lud18PayerDataEmail TEXT NULL");
     },
   },
+  // Version 39
+  {
+    async beforeLnd(db, i) {
+      if (Chain === "testnet" || Chain === "mainnet") {
+        const neutrinoPeers = DEFAULT_NEUTRINO_NODE?.split(",");
+
+        await setItemObject<string[]>(StorageItem.neutrinoPeers, neutrinoPeers || []);
+      }
+    },
+  },
 ];

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -535,6 +535,16 @@ export const model: IStoreModel = {
 
     const nodeBackend = lndChainBackend === "neutrino" ? "neutrino" : "bitcoind";
 
+    let neutrinoPeerConfig = "";
+    if (nodeBackend === "neutrino") {
+      // If there is only 1 peer, use `neutrino.connect`, otherwise `neutrino.addpeer`
+      if (neutrinoPeers.length === 1) {
+        neutrinoPeerConfig = `neutrino.connect=${neutrinoPeers[0]}`;
+      } else {
+        neutrinoPeerConfig = neutrinoPeers.map((peer) => `neutrino.addpeer=${peer}`).join("\n");
+      }
+    }
+
     const config = `
 [Application Options]
 debuglevel=${lndLogLevel}
@@ -563,13 +573,13 @@ ${
   lndChainBackend === "neutrino"
     ? `
 [Neutrino]
+${neutrinoPeerConfig}
 neutrino.feeurl=${neutrinoFeeUrl}
 neutrino.broadcasttimeout=11s
 neutrino.persistfilters=true
 `
     : ""
 }
-${`${neutrinoPeers.map((peer) => `neutrino.addpeer=${peer}`).join("\n")}`}
 
 ${
   lndChainBackend === "bitcoindWithZmq"

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -8,7 +8,6 @@ import { AlertButton, NativeModules } from "react-native";
 import {
   DEFAULT_PATHFINDING_ALGORITHM,
   DEFAULT_SPEEDLOADER_SERVER,
-  MAINNET_NEUTRINO_PEERS,
   PLATFORM,
 } from "../utils/constants";
 import { Chain, VersionCode } from "../utils/build";
@@ -564,24 +563,13 @@ ${
   lndChainBackend === "neutrino"
     ? `
 [Neutrino]
-${neutrinoPeers[0] !== undefined ? `neutrino.addpeer=${neutrinoPeers[0]}` : ""}
 neutrino.feeurl=${neutrinoFeeUrl}
 neutrino.broadcasttimeout=11s
 neutrino.persistfilters=true
 `
     : ""
 }
-${
-  node === "mainnet"
-    ? `
-  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.blixt}
-  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.kevin}
-  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.lightningLabs}
-  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.nitesh}
-  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.zeus}
-  `
-    : ""
-} 
+${`${neutrinoPeers.map((peer) => `neutrino.addpeer=${peer}`).join("\n")}`}
 
 ${
   lndChainBackend === "bitcoindWithZmq"

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -8,6 +8,7 @@ import { AlertButton, NativeModules } from "react-native";
 import {
   DEFAULT_PATHFINDING_ALGORITHM,
   DEFAULT_SPEEDLOADER_SERVER,
+  MAINNET_NEUTRINO_PEERS,
   PLATFORM,
 } from "../utils/constants";
 import { Chain, VersionCode } from "../utils/build";
@@ -563,13 +564,24 @@ ${
   lndChainBackend === "neutrino"
     ? `
 [Neutrino]
-${neutrinoPeers[0] !== undefined ? `neutrino.connect=${neutrinoPeers[0]}` : ""}
+${neutrinoPeers[0] !== undefined ? `neutrino.addpeer=${neutrinoPeers[0]}` : ""}
 neutrino.feeurl=${neutrinoFeeUrl}
 neutrino.broadcasttimeout=11s
 neutrino.persistfilters=true
 `
     : ""
 }
+${
+  node === "mainnet"
+    ? `
+  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.blixt}
+  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.kevin}
+  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.lightningLabs}
+  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.nitesh}
+  neutrino.addpeer=${MAINNET_NEUTRINO_PEERS.zeus}
+  `
+    : ""
+} 
 
 ${
   lndChainBackend === "bitcoindWithZmq"

--- a/src/storage/app.ts
+++ b/src/storage/app.ts
@@ -201,8 +201,7 @@ export const setupApp = async () => {
   let neutrinoFeeUrl = "";
   if (Chain === "mainnet" || Chain === "testnet") {
     lndChainBackend = "neutrino";
-    neutrinoPeers = DEFAULT_NEUTRINO_NODE?.split(",").map((peer) => peer.trim()) || [];
-
+    neutrinoPeers = DEFAULT_NEUTRINO_NODE;
     neutrinoFeeUrl = "https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json";
   }
 

--- a/src/storage/app.ts
+++ b/src/storage/app.ts
@@ -201,7 +201,8 @@ export const setupApp = async () => {
   let neutrinoFeeUrl = "";
   if (Chain === "mainnet" || Chain === "testnet") {
     lndChainBackend = "neutrino";
-    neutrinoPeers.push(DEFAULT_NEUTRINO_NODE);
+    neutrinoPeers = DEFAULT_NEUTRINO_NODE?.split(",").map((peer) => peer.trim()) || [];
+
     neutrinoFeeUrl = "https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json";
   }
 

--- a/src/utils/chain-select.ts
+++ b/src/utils/chain-select.ts
@@ -1,6 +1,6 @@
 import { Chain } from "./build";
 
-export function chainSelect<T>(chains: { mainnet: T; testnet?: T; regtest?: T; signet?: T }) {
+export function chainSelect<T>(chains: { mainnet: T; testnet: T; regtest: T; signet: T }) {
   if (Chain === "mainnet") {
     return chains.mainnet;
   } else if (Chain === "testnet") {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,11 +21,16 @@ export const PLATFORM = Platform.OS;
 export const MATH_PAD_NATIVE_ID = "MATH_PAD";
 
 export const DEFAULT_NEUTRINO_NODE = chainSelect({
-  mainnet:
-    "node.blixtwallet.com,btcd.lnolymp.us,neutrino.noderunner.wtf,node.eldamar.icu,btcd-mainnet.lightning.computer",
-  testnet: "testnet.blixtwallet.com",
-  regtest: "",
-  signet: "",
+  mainnet: [
+    "node.blixtwallet.com",
+    "btcd.lnolymp.us",
+    "neutrino.noderunner.wtf",
+    "node.eldamar.icu",
+    "btcd-mainnet.lightning.computer",
+  ],
+  testnet: ["testnet.blixtwallet.com"],
+  regtest: [],
+  signet: [],
 });
 export const DEFAULT_INVOICE_EXPIRY = 3600;
 export const DEFAULT_MAX_LN_FEE_PERCENTAGE = 2;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,7 +21,8 @@ export const PLATFORM = Platform.OS;
 export const MATH_PAD_NATIVE_ID = "MATH_PAD";
 
 export const DEFAULT_NEUTRINO_NODE = chainSelect({
-  mainnet: "node.blixtwallet.com",
+  mainnet:
+    "node.blixtwallet.com,btcd.lnolymp.us,neutrino.noderunner.wtf,node.eldamar.icu,btcd-mainnet.lightning.computer",
   testnet: "testnet.blixtwallet.com",
   regtest: "",
   signet: "",
@@ -75,11 +76,3 @@ export const BLIXT_NODE_PUBKEY =
   Chain === "mainnet"
     ? "0230a5bca558e6741460c13dd34e636da28e52afd91cf93db87ed1b0392a7466eb"
     : "036b7130b27a23d6fe1d55c1d3bed9e6da5a17090588b0834e8200e0d50ee6886a";
-
-export const MAINNET_NEUTRINO_PEERS = {
-  blixt: "node.blixtwallet.com",
-  zeus: "btcd.lnolymp.us",
-  nitesh: "neutrino.noderunner.wtf",
-  kevin: "node.eldamar.icu",
-  lightningLabs: "btcd-mainnet.lightning.computer",
-};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -75,3 +75,11 @@ export const BLIXT_NODE_PUBKEY =
   Chain === "mainnet"
     ? "0230a5bca558e6741460c13dd34e636da28e52afd91cf93db87ed1b0392a7466eb"
     : "036b7130b27a23d6fe1d55c1d3bed9e6da5a17090588b0834e8200e0d50ee6886a";
+
+export const MAINNET_NEUTRINO_PEERS = {
+  blixt: "node.blixtwallet.com",
+  zeus: "btcd.lnolymp.us",
+  nitesh: "neutrino.noderunner.wtf",
+  kevin: "node.eldamar.icu",
+  lightningLabs: "btcd-mainnet.lightning.computer",
+};

--- a/src/windows/InitProcess/DEV_Commands.tsx
+++ b/src/windows/InitProcess/DEV_Commands.tsx
@@ -910,6 +910,9 @@ export default function DEV_Commands({ navigation, continueCallback }: IProps) {
           <Button small onPress={async () => await setItemObject(StorageItem.appVersion, 28)}>
             <Text style={styles.buttonText}>appVersion = 28</Text>
           </Button>
+          <Button small onPress={async () => await setItemObject(StorageItem.appVersion, 38)}>
+            <Text style={styles.buttonText}>appVersion = 38</Text>
+          </Button>
           <Button
             small
             onPress={async () => {

--- a/src/windows/Settings/Settings.tsx
+++ b/src/windows/Settings/Settings.tsx
@@ -747,7 +747,7 @@ ${t("LN.inbound.dialog.msg3")}`;
         },
       ],
       "plain-text",
-      neutrinoPeers[0] ?? "",
+      neutrinoPeers.join(",") ?? "",
     );
   };
   const onSetBitcoinNodeLongPress = async () => {
@@ -763,7 +763,7 @@ ${t("LN.inbound.dialog.msg3")}`;
           style: "default",
           text: t("buttons.yes", { ns: namespaces.common }),
           onPress: async () => {
-            await changeNeutrinoPeers([DEFAULT_NEUTRINO_NODE]);
+            await changeNeutrinoPeers(DEFAULT_NEUTRINO_NODE);
             await writeConfig();
             restartNeeded();
           },

--- a/src/windows/Settings/Settings.tsx
+++ b/src/windows/Settings/Settings.tsx
@@ -730,12 +730,13 @@ ${t("LN.inbound.dialog.msg3")}`;
         {
           text: t("bitcoinNetwork.node.setDialog.title"),
           onPress: async (text) => {
-            if (text === neutrinoPeers[0]) {
+            if (text === neutrinoPeers.join(",")) {
               return;
             }
 
             if (text) {
-              await changeNeutrinoPeers([text]);
+              const neutrinoPeers = text.split(",").map((n) => n.trim());
+              await changeNeutrinoPeers(neutrinoPeers);
             } else {
               await changeNeutrinoPeers([]);
             }


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <84944042+niteshbalusu11@users.noreply.github.com>

- Added more mainnet neutrino peers.
- Switched from `neutrino.connect` to `neutrino.addpeer`

Now LND will attempt to get info from multiple peers, `neutrino.connect` is forcing lnd to get block data from one node, if that fails then it doesn't attempt to get data from more peers even if you add them. 
Now if the user wants to switch the node in the config, their node will become one of the nodes blixt gets block data from instead of being the only node to talk to.