### PR TITLE
Run speedloader on initial app start

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -325,7 +325,7 @@ export const model: IStoreModel = {
         const speed = setTimeout(() => {
           actions.setSpeedloaderLoading(true);
         }, 3000);
-        if (gossipSyncEnabled && !firstStartup && Chain === "mainnet") {
+        if (gossipSyncEnabled && Chain === "mainnet") {
           if (enforceSpeedloaderOnStartup) {
             log.d("Clearing speedloader files");
             try {


### PR DESCRIPTION
Previously, we would only run on subsequent app starts, due to user experience issue being bad if the user has too wait too long the first time they try to use Blixt.