### PR TITLE
bugfix for force close function

### DIFF
--- a/src/components/PendingChannelCard.tsx
+++ b/src/components/PendingChannelCard.tsx
@@ -65,8 +65,8 @@ export const PendingChannelCard = ({ channel, type, alias }: IPendingChannelCard
       return;
     }
 
-    if (!!channel.closingTxid || channel.closingTxid !== "") {
-      Alert.alert("Closing Tx Has Already Been Broadcasted");
+    if (!!channel.closingTxid && channel.closingTxid !== "") {
+      Alert.alert(`Closing Tx Has Already Been Broadcasted:\n${channel.closingTxid}`);
       return;
     }
 


### PR DESCRIPTION
### Summary  
I stumbled upon a possible bug in forceClose(). the logic that checks whether a closing transaction has already been broadcast seems flawed. It blocks even when no `closingTxid` is present. This patch adjusts the condition to behave as intended and improves the alert message to include the txid.

### Rationale  
Current code:

```ts
if (!!channel.closingTxid || channel.closingTxid !== "") {
  Alert.alert("Closing Tx Has Already Been Broadcasted");
  return;
}
```

This incorrectly triggers when `closingTxid` is `undefined` or `null`, due to the use of `||`. These values satisfy `channel.closingTxid !== ""`, so the guard wrongly blocks the force-close path.
So I'm guessing here that `null` / `undefined` should **not** mean “already broadcast” unless theres some logic I overlooked. 

### Change

* Minimal change: `||` replaced with `&&`.  
* Adds the txid to the alert for clarity

Force-close now behaves correctly and only blocks when an actual txid is already present. Prevents false negatives caused by nullish values.

PS love blixt, thanks for the work!