### PR TITLE
Blixt autopilot

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -807,6 +807,16 @@
         "title": "Automatically open channels",
         "subtitle": ""
       },
+      "autopilotNodePubkey": {
+        "title": "Node for automatic channel opener",
+        "setDialog": {
+          "title": "Set node"
+        },
+        "restoreDialog": {
+          "title": "Restore automatic channel opener node",
+          "msg": "Would you like to restore to the default node"
+        }
+      },
       "inbound": {
         "title": "Inbound channel services",
         "subtitle": "Use an inbound channel service for receiving payments",

--- a/src/components/ChannelCard.tsx
+++ b/src/components/ChannelCard.tsx
@@ -32,7 +32,6 @@ export function ChannelCard({ channel, alias }: IChannelCardProps) {
   const getChannels = useStoreActions((store) => store.channel.getChannels);
   const autopilotEnabled = useStoreState((store) => store.settings.autopilotEnabled);
   const changeAutopilotEnabled = useStoreActions((store) => store.settings.changeAutopilotEnabled);
-  const setupAutopilot = useStoreActions((store) => store.lightning.setupAutopilot);
   const bitcoinUnit = useStoreState((store) => store.settings.bitcoinUnit);
   const fiatUnit = useStoreState((store) => store.settings.fiatUnit);
   const currentRate = useStoreState((store) => store.fiat.currentRate);
@@ -105,7 +104,6 @@ export function ChannelCard({ channel, alias }: IChannelCardProps) {
                       text: "Yes",
                       onPress: async () => {
                         changeAutopilotEnabled(false);
-                        setupAutopilot(false);
                       },
                     },
                   ],

--- a/src/state/Autopilot.ts
+++ b/src/state/Autopilot.ts
@@ -1,0 +1,246 @@
+import { Action, Thunk, action, thunk } from "easy-peasy";
+import { BLIXT_NODE_PUBKEY } from "../utils/constants";
+import { toast } from "../utils";
+import type { IStoreInjections } from "./store";
+import type { IStoreModel } from "./index";
+import { Alert } from "../utils/alert";
+import logger from "./../utils/log";
+
+import { getNodeInfo, subscribeTransactions, walletBalance } from "react-native-turbo-lnd";
+import { convertBitcoinToFiat, formatBitcoin } from "../utils/bitcoin-units";
+import { NodeInfo } from "react-native-turbo-lnd/protos/lightning_pb";
+
+const log = logger("Autopilot");
+
+export interface IAutopilotModel {
+  initialize: Thunk<IAutopilotModel, void, IStoreInjections, IStoreModel>;
+  checkAutopilot: Thunk<
+    IAutopilotModel,
+    { force?: boolean } | undefined,
+    IStoreInjections,
+    IStoreModel,
+    Promise<void>
+  >;
+
+  setAutopilotPrompting: Action<IAutopilotModel, boolean>;
+  setAutopilotOpening: Action<IAutopilotModel, boolean>;
+  setTransactionSubscriptionStarted: Action<IAutopilotModel, boolean>;
+
+  autopilotPrompting: boolean;
+  autopilotOpening: boolean;
+  transactionSubscriptionStarted: boolean;
+}
+
+export const autopilot: IAutopilotModel = {
+  initialize: thunk(async (actions, _, { getState, getStoreActions, getStoreState }) => {
+    log.i("Initializing");
+    if (getState().transactionSubscriptionStarted) {
+      log.d("Autopilot.initialize called when subscription already started");
+      return;
+    }
+
+    subscribeTransactions(
+      {},
+      async (transaction) => {
+        try {
+          log.i("Event SubscribeTransactions", [transaction.txHash]);
+          if (
+            transaction.numConfirmations < 1 ||
+            getStoreState().onChain.transactionNotificationBlacklist.includes(transaction.txHash) ||
+            Number(transaction.amount) < 0
+          ) {
+            return;
+          }
+
+          log.i("Running checkAutopilot()");
+          await actions.checkAutopilot();
+        } catch (error: any) {
+          toast(error.message, undefined, "danger");
+        }
+      },
+      (error) => {
+        log.e("Got error from SubscribeTransactions", [error]);
+      },
+    );
+
+    actions.setTransactionSubscriptionStarted(true);
+    await getStoreActions().onChain.getBalance();
+  }),
+
+  checkAutopilot: thunk(
+    async (actions, payload = {}, { getState, getStoreState, getStoreActions }) => {
+      const autopilotPrompting = getState().autopilotPrompting;
+      const autopilotOpening = getState().autopilotOpening;
+      const autopilotNodePubkey = getStoreState().settings.autopilotNodePubkey;
+      const autopilotEnabled = getStoreState().settings.autopilotEnabled;
+      const torEnabled = getStoreState().settings.torEnabled;
+
+      log.i("checkAutopilot()", [
+        "autopilotPrompting " + autopilotPrompting,
+        "autopilotOpening " + autopilotOpening,
+        "autopilotNodePubkey " + autopilotNodePubkey,
+        "autopilotEnabled " + autopilotEnabled,
+        "force " + payload.force,
+      ]);
+
+      if (!autopilotEnabled && !payload.force) {
+        log.d("Autopilot is not enabled, skipping");
+        return;
+      }
+
+      if (!autopilotNodePubkey) {
+        log.d("Autopilot node pubkey is not set, skipping");
+        return;
+      }
+
+      if (autopilotPrompting || autopilotOpening) {
+        log.d("Autopilot is already prompting or opening, skipping");
+        return;
+      }
+
+      if (!getStoreState().lightning.syncedToChain) {
+        log.d("Not synced to chain, skipping");
+        return;
+      }
+
+      const balance = await walletBalance({});
+      const availableBalance = balance.confirmedBalance;
+      // We need at least 22,000 satoshi to open a channel, 20k sats is usually the limit node's set
+      // and the user needs some more for transaction fees.
+      if (!payload.force && availableBalance < 22000n) {
+        log.d("Available balance is less than 22,000 satoshi, skipping");
+        return;
+      }
+
+      const bitcoinUnit = getStoreState().settings.bitcoinUnit;
+      const currentRate = getStoreState().fiat.currentRate;
+      const fiatUnit = getStoreState().settings.fiatUnit;
+
+      const availableBalanceFormatted = formatBitcoin(availableBalance, bitcoinUnit);
+      const availableBalanceInFiatFormatted = convertBitcoinToFiat(
+        availableBalance,
+        currentRate,
+        fiatUnit,
+      );
+
+      actions.setAutopilotPrompting(true);
+      try {
+        const peer = await getAutopilotPeerUri(autopilotNodePubkey, torEnabled);
+        let feeRate = undefined;
+
+        let message = `You have ${availableBalanceFormatted} (${availableBalanceInFiatFormatted}) on chain.\n\n`;
+        if (BLIXT_NODE_PUBKEY === autopilotNodePubkey) {
+          message += `Would you like to open a new channel to the Blixt LSP node now?`;
+        } else {
+          message += `Would you like to open a new channel to the configured autopilot node (${autopilotNodePubkey}) now?`;
+        }
+
+        const prompt = await Alert.promiseAlert("Automatic channel opening", message, [
+          { text: "Yes" },
+          { text: "Yes and set custom feerate" },
+          { text: "No and disable autopilot", style: "cancel" },
+        ]);
+
+        if (prompt.style === "cancel") {
+          await getStoreActions().settings.changeAutopilotEnabled(false);
+          return;
+        }
+
+        if (prompt.text === "Yes and set custom feerate") {
+          const feeRatePrompt = await Alert.promisePromptCallback(
+            "Set custom feerate",
+            "Enter the feerate in sat/vB for opening the channel (1-100).",
+            "plain-text",
+            undefined,
+            "number-pad",
+          );
+          if (feeRatePrompt === null) {
+            log.i("User cancelled feerate prompt");
+            return;
+          }
+
+          feeRate = Number.parseInt(feeRatePrompt, 10);
+
+          if (feeRate === -1 || Number.isNaN(feeRate) || feeRate < 1 || feeRate > 100) {
+            Alert.alert(
+              "Invalid feerate",
+              `Invalid feerate "${feeRatePrompt}".\n\nPlease enter a value between 1 and 100`,
+            );
+            return;
+          }
+        }
+
+        actions.setAutopilotOpening(true);
+        try {
+          await getStoreActions().channel.connectAndOpenChannelAll({ peer, feeRateSat: feeRate });
+          await getStoreActions().channel.getChannels();
+        } finally {
+          actions.setAutopilotOpening(false);
+        }
+      } catch (error: any) {
+        log.e("Auto-open channel failed", [error]);
+        if (getStoreState().lightning.syncedToGraph) {
+          toast(`Error while auto-opening channel: ${error.message}`, 30000, "danger", "OK");
+        } else {
+          log.i("Skipping autopilot error toast before graph sync; will retry after sync");
+        }
+      } finally {
+        actions.setAutopilotPrompting(false);
+      }
+    },
+  ),
+
+  setAutopilotPrompting: action((state, payload) => {
+    state.autopilotPrompting = payload;
+  }),
+  setAutopilotOpening: action((state, payload) => {
+    state.autopilotOpening = payload;
+  }),
+  setTransactionSubscriptionStarted: action((state, payload) => {
+    state.transactionSubscriptionStarted = payload;
+  }),
+
+  autopilotPrompting: false,
+  autopilotOpening: false,
+  transactionSubscriptionStarted: false,
+};
+
+/**
+ *
+ * @throws Error if the node pubkey is not found in the graph or if no suitable address is found
+ * @returns The peer URI for the autopilot peer
+ */
+const getAutopilotPeerUri = async (nodePubkey: string, preferTor: boolean): Promise<string> => {
+  let nodeInfo: NodeInfo;
+  try {
+    nodeInfo = await getNodeInfo({ pubKey: nodePubkey });
+  } catch (error: any) {
+    log.w("Could not get node address from graph for autopilot peer", [error.message]);
+    throw new Error(`Could not get node address from graph for autopilot peer: ${error.message}`);
+  }
+
+  const nodeAddresses =
+    nodeInfo.node?.addresses?.filter(({ addr }) => typeof addr === "string" && addr.length > 0) ??
+    [];
+
+  const torAddress = nodeAddresses.find(({ addr }) => addr.toLowerCase().includes(".onion"));
+  const clearnetAddress = nodeAddresses.find(({ addr }) => !addr.toLowerCase().includes(".onion"));
+
+  let nodeAddress: (typeof nodeAddresses)[number] | undefined;
+  if (preferTor) {
+    if (torAddress) {
+      nodeAddress = torAddress;
+    } else if (clearnetAddress) {
+      nodeAddress = clearnetAddress;
+    }
+  } else {
+    if (clearnetAddress) {
+      nodeAddress = clearnetAddress;
+    }
+  }
+  if (!nodeAddress) {
+    throw new Error("No suitable address found for autopilot peer");
+  }
+
+  return `${nodePubkey}@${nodeAddress.addr}`;
+};

--- a/src/state/OnChain.ts
+++ b/src/state/OnChain.ts
@@ -113,7 +113,7 @@ export const onChain: IOnChainModel = {
         {},
         async (transaction) => {
           try {
-            log.d("Event SubscribeTransactions", []);
+            log.d("Event SubscribeTransactions", [transaction]);
 
             await actions.getBalance();
 

--- a/src/state/Settings.ts
+++ b/src/state/Settings.ts
@@ -52,6 +52,7 @@ export interface ISettingsModel {
   changeName: Thunk<ISettingsModel, string | null>;
   changeLanguage: Thunk<ISettingsModel, string>;
   changeAutopilotEnabled: Thunk<ISettingsModel, boolean>;
+  changeAutopilotNodePubkey: Thunk<ISettingsModel, string>;
   changePushNotificationsEnabled: Thunk<ISettingsModel, boolean>;
   changeClipboardInvoiceCheckEnabled: Thunk<ISettingsModel, boolean>;
   changeScheduledSyncEnabled: Thunk<ISettingsModel, boolean>;
@@ -102,6 +103,7 @@ export interface ISettingsModel {
   setName: Action<ISettingsModel, string | null>;
   setLanguage: Action<ISettingsModel, string>;
   setAutopilotEnabled: Action<ISettingsModel, boolean>;
+  setAutopilotNodePubkey: Action<ISettingsModel, string>;
   setPushNotificationsEnabled: Action<ISettingsModel, boolean>;
   setClipboardInvoiceCheckInvoicesEnabled: Action<ISettingsModel, boolean>;
   setScheduledSyncEnabled: Action<ISettingsModel, boolean>;
@@ -152,6 +154,7 @@ export interface ISettingsModel {
   name: string | null;
   language: string;
   autopilotEnabled: boolean;
+  autopilotNodePubkey: string;
   pushNotificationsEnabled: boolean;
   clipboardInvoiceCheckEnabled: boolean;
   scheduledSyncEnabled: boolean;
@@ -216,7 +219,10 @@ export const settings: ISettingsModel = {
     actions.setFiatUnit((await getItemObject(StorageItem.fiatUnit)) || "USD");
     actions.setName((await getItemObject(StorageItem.name)) || null);
     actions.setLanguage((await getItemObject(StorageItem.language)) || "en");
-    actions.setAutopilotEnabled(await getItemObject(StorageItem.autopilotEnabled || false));
+    actions.setAutopilotEnabled((await getItemObject(StorageItem.autopilotEnabled)) ?? true);
+    actions.setAutopilotNodePubkey(
+      (await getItemObject(StorageItem.autopilotNodePubkey)) || BLIXT_NODE_PUBKEY,
+    );
     actions.setPushNotificationsEnabled(
       await getItemObject(StorageItem.pushNotificationsEnabled || false),
     );
@@ -335,6 +341,11 @@ export const settings: ISettingsModel = {
   changeAutopilotEnabled: thunk(async (actions, payload) => {
     await setItemObject(StorageItem.autopilotEnabled, payload);
     actions.setAutopilotEnabled(payload);
+  }),
+
+  changeAutopilotNodePubkey: thunk(async (actions, payload) => {
+    await setItemObject(StorageItem.autopilotNodePubkey, payload);
+    actions.setAutopilotNodePubkey(payload);
   }),
 
   changePushNotificationsEnabled: thunk(async (actions, payload) => {
@@ -572,6 +583,9 @@ export const settings: ISettingsModel = {
   setAutopilotEnabled: action((state, payload) => {
     state.autopilotEnabled = payload;
   }),
+  setAutopilotNodePubkey: action((state, payload) => {
+    state.autopilotNodePubkey = payload;
+  }),
   setPushNotificationsEnabled: action((state, payload) => {
     state.pushNotificationsEnabled = payload;
   }),
@@ -710,7 +724,8 @@ export const settings: ISettingsModel = {
   fiatUnit: "USD",
   name: null,
   language: "en",
-  autopilotEnabled: false,
+  autopilotEnabled: true,
+  autopilotNodePubkey: BLIXT_NODE_PUBKEY,
   pushNotificationsEnabled: false,
   clipboardInvoiceCheckEnabled: false,
   scheduledSyncEnabled: false,
@@ -771,7 +786,7 @@ export const settings: ISettingsModel = {
 
     const autopilotEnabled = rand(0, 1) === 1;
     state.setAutopilotEnabled(autopilotEnabled);
-    dispatch.lightning.setupAutopilot(autopilotEnabled);
+    state.setAutopilotNodePubkey(BLIXT_NODE_PUBKEY);
 
     state.setPushNotificationsEnabled(rand(0, 1) === 1);
     state.setClipboardInvoiceCheckInvoicesEnabled(rand(0, 1) === 1);

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -25,6 +25,7 @@ import { IFiatModel, fiat } from "./Fiat";
 import { IGoogleDriveBackupModel, googleDriveBackup } from "./GoogleDriveBackup";
 import { IGoogleModel, google } from "./Google";
 import { IICloudBackupModel, iCloudBackup } from "./ICloudBackup";
+import { IAutopilotModel, autopilot } from "./Autopilot";
 import { ILNUrlModel, lnUrl } from "./LNURL";
 import { ILightNameModel, lightName } from "./LightName";
 import { ILightningModel, LndChainBackend, lightning } from "./Lightning";
@@ -157,6 +158,7 @@ export interface IStoreModel {
   fiat: IFiatModel;
   security: ISecurityModel;
   settings: ISettingsModel;
+  autopilot: IAutopilotModel;
   clipboardManager: IClipboardManagerModel;
   scheduledSync: IScheduledSyncModel;
   lnUrl: ILNUrlModel;
@@ -872,6 +874,7 @@ routerrpc.estimator=${lndPathfindingAlgorithm}
   send,
   receive,
   onChain,
+  autopilot,
   fiat,
   security,
   settings,

--- a/src/storage/app.ts
+++ b/src/storage/app.ts
@@ -44,6 +44,7 @@ export enum StorageItem {
   language = "language",
   walletPassword = "walletPassword",
   autopilotEnabled = "autopilotEnabled",
+  autopilotNodePubkey = "autopilotNodePubkey",
   pushNotificationsEnabled = "pushNotificationsEnabled",
   clipboardInvoiceCheck = "clipboardInvoiceCheck",
   scheduledSyncEnabled = "scheduledSyncEnabled",
@@ -185,6 +186,7 @@ export const clearApp = async () => {
     removeItem(StorageItem.language),
     removeItem(StorageItem.walletPassword),
     removeItem(StorageItem.autopilotEnabled),
+    removeItem(StorageItem.autopilotNodePubkey),
     removeItem(StorageItem.pushNotificationsEnabled),
     removeItem(StorageItem.clipboardInvoiceCheck),
     removeItem(StorageItem.scheduledSyncEnabled),
@@ -280,6 +282,7 @@ export const setupApp = async () => {
     setItemObject<string>(StorageItem.language, "en"),
     // walletPassword
     setItemObject<boolean>(StorageItem.autopilotEnabled, true),
+    setItemObject<string>(StorageItem.autopilotNodePubkey, BLIXT_NODE_PUBKEY),
     setItemObject<boolean>(StorageItem.pushNotificationsEnabled, true),
     setItemObject<boolean>(StorageItem.clipboardInvoiceCheck, PLATFORM === "ios" ? false : true),
     setItemObject<boolean>(StorageItem.scheduledSyncEnabled, false),

--- a/src/utils/alert.ts
+++ b/src/utils/alert.ts
@@ -9,35 +9,35 @@ class WebAlert implements AlertStatic {
   public alert(title: string, message?: string, buttons?: AlertButton[]): void {
     if (PLATFORM === "web") {
       if (buttons === undefined || buttons.length === 0) {
-        window.alert([title, message].filter(Boolean).join('\n'));
+        window.alert([title, message].filter(Boolean).join("\n"));
         return;
       }
 
-      const result = window.confirm([title, message].filter(Boolean).join('\n'));
+      const result = window.confirm([title, message].filter(Boolean).join("\n"));
 
       if (result === true) {
-        const confirm = buttons.find(({ style }) => style !== 'cancel');
+        const confirm = buttons.find(({ style }) => style !== "cancel");
         confirm?.onPress?.();
         return;
       }
 
-      const cancel = buttons.find(({ style }) => style === 'cancel');
+      const cancel = buttons.find(({ style }) => style === "cancel");
       cancel?.onPress?.();
     } else {
-      RealAlert.alert(
-        title,
-        message,
-        buttons,
-      );
+      RealAlert.alert(title, message, buttons);
     }
   }
 
-  public promiseAlert(title: string, message: string | undefined, buttons: AlertButton[]): Promise<AlertButton> {
+  public promiseAlert(
+    title: string,
+    message: string | undefined,
+    buttons: AlertButton[],
+  ): Promise<AlertButton> {
     return new Promise((resolve, reject) => {
       for (const button of buttons) {
         button.onPress = () => {
           resolve(button);
-        }
+        };
       }
 
       this.alert(title, message, buttons);
@@ -70,7 +70,7 @@ class WebAlert implements AlertStatic {
             const cancel = callbackOrButtons.find(({ style }) => style === "cancel");
             cancel?.onPress?.();
           }
-        }
+        },
       });
     } else if (PLATFORM === "web") {
       const result = window.prompt(message, defaultValue);
@@ -89,46 +89,45 @@ class WebAlert implements AlertStatic {
         }
       }
     } else if (PLATFORM === "android") {
-      const positiveText = typeof callbackOrButtons === "object" ? callbackOrButtons.find(
-        (button) => button.style === "default"
-      )?.text : undefined;
-      const negativeText = typeof callbackOrButtons === "object" ? callbackOrButtons.find(
-        (button) => button.style === "cancel"
-      )?.text : undefined;
+      const positiveText =
+        typeof callbackOrButtons === "object"
+          ? callbackOrButtons.find((button) => button.style === "default")?.text
+          : undefined;
+      const negativeText =
+        typeof callbackOrButtons === "object"
+          ? callbackOrButtons.find((button) => button.style === "cancel")?.text
+          : undefined;
 
-      DialogAndroid.prompt(
-        title,
-        message,
-        {
-          defaultValue,
-          positiveText,
-          negativeText,
-          keyboardType,
-        },
-      ).then(({ action, text }: { action: "actionPosisive" | "actionNegative" | "actionDismiss", text: string }) => {
-        if (action === "actionNegative" || action === "actionDismiss") {
-          if (typeof callbackOrButtons === "object") {
-            const cancel = callbackOrButtons.find(({ style }) => style === "cancel");
-            cancel?.onPress?.();
-          }
-        } else {
-          if (typeof callbackOrButtons === "object") {
-            const ok = callbackOrButtons.find(({ style }) => style !== "cancel");
-            ok?.onPress?.(text);
-          } else {
-            callbackOrButtons?.(text);
-          }
-        }
-      });
-    } else {
-      RealAlert.prompt(
-        title,
-        message,
-        callbackOrButtons,
-        type,
+      DialogAndroid.prompt(title, message, {
         defaultValue,
+        positiveText,
+        negativeText,
         keyboardType,
+      }).then(
+        ({
+          action,
+          text,
+        }: {
+          action: "actionPosisive" | "actionNegative" | "actionDismiss";
+          text: string;
+        }) => {
+          if (action === "actionNegative" || action === "actionDismiss") {
+            if (typeof callbackOrButtons === "object") {
+              const cancel = callbackOrButtons.find(({ style }) => style === "cancel");
+              cancel?.onPress?.();
+            }
+          } else {
+            if (typeof callbackOrButtons === "object") {
+              const ok = callbackOrButtons.find(({ style }) => style !== "cancel");
+              ok?.onPress?.(text);
+            } else {
+              callbackOrButtons?.(text);
+            }
+          }
+        },
       );
+    } else {
+      RealAlert.prompt(title, message, callbackOrButtons, type, defaultValue, keyboardType);
     }
   }
 
@@ -137,10 +136,28 @@ class WebAlert implements AlertStatic {
     message?: string,
     type?: AlertType,
     defaultValue?: string,
-    keyboardType?: string
-  ): Promise<string> {
+    keyboardType?: string,
+  ): Promise<string | null> {
     return new Promise((resolve) => {
-      this.prompt(title, message, resolve, type, defaultValue, keyboardType);
+      this.prompt(
+        title,
+        message,
+        [
+          {
+            text: "Cancel",
+            style: "cancel",
+            onPress: () => resolve(null),
+          },
+          {
+            text: "OK",
+            style: "default",
+            onPress: (text?: string) => resolve(text ?? ""),
+          },
+        ],
+        type,
+        defaultValue,
+        keyboardType,
+      );
     });
   }
 }

--- a/src/windows/InitProcess/DEV_Commands.tsx
+++ b/src/windows/InitProcess/DEV_Commands.tsx
@@ -1097,7 +1097,7 @@ export default function DEV_Commands({ navigation, continueCallback }: IProps) {
             small
             onPress={async () => {
               const t = await Alert.promisePromptCallback("lightningBoxAddress");
-              setItem(StorageItem.lightningBoxAddress, t);
+              setItem(StorageItem.lightningBoxAddress, t ?? "");
             }}
           >
             <Text style={styles.buttonText}>lightningBoxAddress prompt</Text>

--- a/src/windows/Settings/PowerUserTools.tsx
+++ b/src/windows/Settings/PowerUserTools.tsx
@@ -87,6 +87,7 @@ export default function PowerUserTools({ navigation }: IPowerUserToolsProps) {
   );
   const setSyncEnabled = useStoreActions((store) => store.scheduledSync.setSyncEnabled);
   const writeConfig = useStoreActions((store) => store.writeConfig);
+  const checkAutopilot = useStoreActions((store) => store.autopilot.checkAutopilot);
 
   const restartNeeded = () => {
     const title = t("bitcoinNetwork.restartDialog.title");
@@ -202,6 +203,15 @@ export default function PowerUserTools({ navigation }: IPowerUserToolsProps) {
     restartNeeded();
   };
 
+  const onPressTriggerAutopilot = async () => {
+    try {
+      toast("Triggering autopilot check");
+      await checkAutopilot({ force: true });
+    } catch (error: any) {
+      toast("Error: " + error.message, 10000, "danger");
+    }
+  };
+
   const onGetNodeInfoPress = async () => {
     Alert.prompt(
       "Get node info",
@@ -270,6 +280,11 @@ export default function PowerUserTools({ navigation }: IPowerUserToolsProps) {
         "Provide payment hash",
         "plain-text",
       );
+
+      if (hash === null) {
+        return;
+      }
+
       const invoice = await lookupInvoice({
         rHashStr: hash,
       });
@@ -620,6 +635,13 @@ export default function PowerUserTools({ navigation }: IPowerUserToolsProps) {
         writeConfig();
         toast(t("msg.written", { ns: namespaces.common }));
       },
+    },
+    {
+      type: "item",
+      icon: { type: "MaterialCommunityIcons", name: "flash-outline" },
+      title: "Trigger autopilot check",
+      subtitle: "Run custom channel-open autopilot now",
+      onPress: onPressTriggerAutopilot,
     },
     {
       type: "item",

--- a/tests/easy-peasy/Lightning.ts
+++ b/tests/easy-peasy/Lightning.ts
@@ -9,6 +9,13 @@ jest.setTimeout(20000);
 test("initialize lightning store", async () => {
   const store = await initCommonStore(true);
 
-  await waitFor(() => expect(store.getState().lightning.syncedToChain).toBe(true), { timeout: 5000 });
-  await waitFor(() => expect(store.getState().lightning.autopilotSet).toBeDefined(), { timeout: 5000 });
+  await waitFor(() => expect(store.getState().lightning.syncedToChain).toBe(true), {
+    timeout: 5000,
+  });
+  await waitFor(
+    () => expect(store.getState().autopilot.transactionSubscriptionStarted).toBe(true),
+    {
+      timeout: 5000,
+    },
+  );
 });

--- a/tests/utils.tsx
+++ b/tests/utils.tsx
@@ -67,7 +67,9 @@ export const initCommonStore = async (waitUntilReady = false) => {
     await waitFor(() => expect(store.getState().lightning.syncedToGraph).toBe(true), {
       timeout: 5000,
     });
-    await waitFor(() => expect(store.getState().lightning.autopilotSet).toBeDefined());
+    await waitFor(() =>
+      expect(store.getState().autopilot.transactionSubscriptionStarted).toBe(true),
+    );
     await waitFor(() => expect(store.getState().receive.invoiceSubscriptionStarted).toBe(true), {
       timeout: 5000,
     });


### PR DESCRIPTION
This PR removes the usage of lnd's internal autopilot in favor of our own. We introduce the Autopilot easy-peasy store which will listen to incoming onchain transactions and check 

This way we have have more control over how it's supposed to function -- for example we now prompt the user whether they want to open a channel, and can also choose to set a custom fee rate.